### PR TITLE
fix: resolve invalid format marker and detect future occurences

### DIFF
--- a/components/agent/default/source-map.mjs
+++ b/components/agent/default/source-map.mjs
@@ -15,7 +15,7 @@ export default (dependencies) => {
           content = readFile(maybe_url);
         } catch (error) {
           logWarning(
-            "Cannot read source-map file at %j extracted from %j >> %e",
+            "Cannot read source-map file at %j extracted from %j >> %O",
             maybe_url,
             file.url,
             error,

--- a/components/build.mjs
+++ b/components/build.mjs
@@ -5,10 +5,7 @@ import {
 } from "../build/component/dynamic.mjs";
 
 const generate = (buildAsync) => (specifier, blueprint) =>
-  buildAsync("test", specifier, {
-    log: "off",
-    ...blueprint,
-  });
+  buildAsync("test", specifier, blueprint);
 
 export const buildTestDependenciesAsync = generate(buildDependenciesAsync);
 export const buildTestComponentsAsync = generate(buildComponentsAsync);

--- a/components/hook-http/node/index.mjs
+++ b/components/hook-http/node/index.mjs
@@ -64,7 +64,7 @@ export default (dependencies) => {
     try {
       return parseJSON(string);
     } catch (error) {
-      logWarning("Could not parse as JSON %j >> %e", string, error);
+      logWarning("Could not parse as JSON %j >> %O", string, error);
       return recovery;
     }
   };
@@ -73,7 +73,7 @@ export default (dependencies) => {
     try {
       return new TextDecoder(encoding).decode(buffer);
     } catch (error) {
-      logWarning("Could not decode as %j buffer >> %e", encoding, error);
+      logWarning("Could not decode as %j buffer >> %O", encoding, error);
       return recovery;
     }
   };

--- a/components/log-inner/stub/.build.yml
+++ b/components/log-inner/stub/.build.yml
@@ -1,0 +1,2 @@
+branches: [test]
+dependencies: [util]

--- a/components/log-inner/stub/index.mjs
+++ b/components/log-inner/stub/index.mjs
@@ -1,0 +1,14 @@
+export default (dependencies) => {
+  const {
+    util: { format },
+  } = dependencies;
+  const checkFormat = (template, ...values) => {
+    format(template, values);
+  };
+  return {
+    logDebug: checkFormat,
+    logInfo: checkFormat,
+    logWarning: checkFormat,
+    logError: checkFormat,
+  };
+};

--- a/components/log-inner/stub/index.test.mjs
+++ b/components/log-inner/stub/index.test.mjs
@@ -1,0 +1,5 @@
+import { buildTestDependenciesAsync } from "../../build.mjs";
+import LogInner from "./index.mjs";
+
+const { logInfo } = LogInner(await buildTestDependenciesAsync(import.meta.url));
+logInfo("foo %s", "bar");

--- a/components/log-inner/write-sync/.build.yml
+++ b/components/log-inner/write-sync/.build.yml
@@ -1,2 +1,2 @@
-branches: [test, node]
+branches: [node]
 dependencies: [util, expect]

--- a/components/log/error/.build.yml
+++ b/components/log/error/.build.yml
@@ -1,2 +1,2 @@
-branches: [test, node, browser]
+branches: [node, browser]
 dependencies: [log-inner]

--- a/components/log/info/.build.yml
+++ b/components/log/info/.build.yml
@@ -1,2 +1,2 @@
-branches: [test, node, browser]
+branches: [node, browser]
 dependencies: [log-inner]

--- a/components/log/off/.build.yml
+++ b/components/log/off/.build.yml
@@ -1,2 +1,2 @@
-branches: [test, node, browser]
+branches: [node, browser]
 dependencies: [log-inner]

--- a/components/log/warning/.build.yml
+++ b/components/log/warning/.build.yml
@@ -1,2 +1,2 @@
-branches: [test, node, browser]
+branches: [node, browser]
 dependencies: [log-inner]

--- a/components/receptor-file/default/index.mjs
+++ b/components/receptor-file/default/index.mjs
@@ -119,7 +119,7 @@ export default (dependencies) => {
             const { recorder } = configuration;
             if (recorder !== "process" && recorder !== "mocha") {
               logError(
-                "File receptor expected process/mocha recorder but got: ",
+                "File receptor expected process/mocha recorder but got: %j",
                 recorder,
               );
               socket.destroy();

--- a/components/receptor-http/default/index.mjs
+++ b/components/receptor-http/default/index.mjs
@@ -147,7 +147,7 @@ export default (dependencies) => {
             const { recorder } = configuration;
             if (recorder !== "remote") {
               logError(
-                "Http receptor expected remote recorder but got: ",
+                "Http receptor expected remote recorder but got: %j",
                 recorder,
               );
               socket.destroy();

--- a/components/serialization/default/index.mjs
+++ b/components/serialization/default/index.mjs
@@ -46,7 +46,7 @@ export default (dependencies) => {
       return ownKeys(object);
     } catch (error) {
       logDebug(
-        "Reflect.ownKeys(%o) threw %e (this should only happen when the object is a proxy)",
+        "Reflect.ownKeys(%o) threw %O (this should only happen when the object is a proxy)",
         object,
         error,
       );
@@ -58,7 +58,7 @@ export default (dependencies) => {
       return getPrototypeOf(object);
     } catch (error) {
       logDebug(
-        "Reflect.getPrototypeOf(%o) threw %e (this should only happen when the object is a proxy)",
+        "Reflect.getPrototypeOf(%o) threw %O (this should only happen when the object is a proxy)",
         object,
         error,
       );
@@ -70,7 +70,7 @@ export default (dependencies) => {
       return getOwnPropertyDescriptor(object, key);
     } catch (error) {
       logDebug(
-        "Reflect.getOwnPropertyDescriptor(%o, %j) threw %e (this should only happen when the object is a proxy)",
+        "Reflect.getOwnPropertyDescriptor(%o, %j) threw %O (this should only happen when the object is a proxy)",
         object,
         key,
         error,

--- a/components/source/default/index.mjs
+++ b/components/source/default/index.mjs
@@ -104,7 +104,7 @@ export default (dependencies) => {
             };
           } else {
             logInfo(
-              "Source map out of range %j at file %j, line %j, and %column %j",
+              "Source map out of range %j at file %j, line %j, and column %j",
               source_index,
               mapping.base,
               line,
@@ -114,7 +114,7 @@ export default (dependencies) => {
           }
         } else {
           logInfo(
-            "Missing source map segment at file %j, line %j, and %column %j",
+            "Missing source map segment at file %j, line %j, and column %j",
             mapping.base,
             line,
             column,


### PR DESCRIPTION
We enable all logs in the testing environment but do not write anything  on the console. That way, we are able to detect invalid marker format.