### PR TITLE
Fix spawn cwd

### DIFF
--- a/components/.ordering
+++ b/components/.ordering
@@ -2,6 +2,7 @@ util
 url
 path
 uuid
+version
 error
 log-inner
 log

--- a/components/error/default/index.mjs
+++ b/components/error/default/index.mjs
@@ -56,9 +56,9 @@ export class ExternalAppmapError extends AppmapError {
 }
 
 export const reportError = (error) => {
-  if (error instanceof InternalAppmapError) {
+  if (error.name === "InternalAppmapError") {
     return internal_message;
-  } else if (error instanceof ExternalAppmapError) {
+  } else if (error.name === "ExternalAppmapError") {
     return external_message;
   } else {
     return unknown_message;

--- a/components/error/default/index.mjs
+++ b/components/error/default/index.mjs
@@ -2,6 +2,8 @@ const { URL, Error } = globalThis;
 
 const { search: __search } = new URL(import.meta.url);
 
+const { version } = await import(`../../version/index.mjs${__search}`);
+
 const issues = "https://github.com/getappmap/appmap-agent-js/issues";
 const slack = "https://appmap.io/slack";
 const documentation =
@@ -9,7 +11,7 @@ const documentation =
 const instruction = "https://appmap.io/docs/appmap-overview.html";
 
 const internal_message = `
-Detected an internal appmap error.\
+[appmap@${version}] Detected an internal appmap error.\
  This is probably an issue with how the AppMap agent is being used.\
  Please consider submitting a bug report at:
   ${issues}
@@ -17,7 +19,7 @@ Detected an internal appmap error.\
 `;
 
 const external_message = `
-Detected an external appmap error.\
+[appmap@${version}] Detected an external appmap error.\
  This is probably an issue with how the AppMap agent is being used.
 - You can look for answers in our installation instructions:
     ${instruction}
@@ -29,7 +31,7 @@ Detected an external appmap error.\
 `;
 
 const unknown_message = `
-Detected an unknown error.\
+[appmap@${version}] Detected an unknown error.\
  Does this error disappear when not recording your application?\
  If yes, this is probably an issue within the appmap framework.\
  Please consider submitting a bug report at:

--- a/components/repository/node/spawn.mjs
+++ b/components/repository/node/spawn.mjs
@@ -12,9 +12,13 @@ const { logWarning, logErrorWhen } = await import(
 );
 const { coalesce, assert } = await import(`../../util/index.mjs${__search}`);
 
+const { convertFileUrlToPath } = await import(
+  `../../path/index.mjs${__search}`
+);
+
 export const spawn = (exec, argv, url) => {
   const result = spawnChildProcess(exec, argv, {
-    cwd: new URL(".", url),
+    cwd: convertFileUrlToPath(new URL(".", url)),
     encoding: "utf8",
     timeout: 1000,
     stdio: ["ignore", "pipe", "pipe"],

--- a/components/version/node/.env
+++ b/components/version/node/.env
@@ -1,0 +1,2 @@
+node
+test

--- a/components/version/node/index.mjs
+++ b/components/version/node/index.mjs
@@ -1,0 +1,10 @@
+const {
+  URL,
+  JSON: { parse: parseJSON },
+} = globalThis;
+
+import { readFile as readFileAsync } from "node:fs/promises";
+
+export const { version } = parseJSON(
+  await readFileAsync(new URL("../../../package.json", import.meta.url)),
+);

--- a/components/version/node/index.test.mjs
+++ b/components/version/node/index.test.mjs
@@ -1,0 +1,5 @@
+import { assertEqual } from "../../__fixture__.mjs";
+
+import { version } from "./index.mjs?env=test";
+
+assertEqual(typeof version, "string");

--- a/lib/node/batch.mjs
+++ b/lib/node/batch.mjs
@@ -5,7 +5,6 @@ import "./error.mjs";
 const { loadProcessConfiguration } = await import(
   `../../components/configuration-process/index.mjs?${new URLSearchParams({
     env: "node",
-    violation: "exit",
     "validate-message": "off",
     "validate-appmap": "off",
   }).toString()}`
@@ -16,7 +15,6 @@ const configuration = loadProcessConfiguration(process);
 const { mainAsync } = await import(
   `../../components/batch/index.mjs?${new URLSearchParams({
     env: "node",
-    violation: "exit",
     "log-level": configuration.log.level,
     "log-file": configuration.log.file,
     socket: configuration.socket,

--- a/lib/node/configuration.mjs
+++ b/lib/node/configuration.mjs
@@ -8,7 +8,6 @@ const {
 const { loadEnvironmentConfiguration } = await import(
   `../../components/configuration-environment/index.mjs?${new URLSearchParams({
     env: "node",
-    violation: "exit",
   }).toString()}`
 );
 
@@ -31,7 +30,6 @@ if (configuration.socket === "unix") {
 
 export const params = new URLSearchParams({
   env: "node",
-  violation: "exit",
   "log-level": configuration.log.level,
   "log-file": configuration.log.file,
   socket: configuration.socket,

--- a/lib/node/recorder-api.mjs
+++ b/lib/node/recorder-api.mjs
@@ -9,7 +9,6 @@ process.env.APPMAP_LOG_FILE = "1";
 
 const params = new URLSearchParams({
   env: "node",
-  violation: "error",
   emitter: "local",
   "validate-message": "off",
   "validate-appmap": "off",


### PR DESCRIPTION
On outdated node14 and node16, `options.cwd` cannot be an url. Even though we are only officially supporting up-to-date major node versions, lets provide this fix.

https://nodejs.org/api/child_process.html#child_processspawncommand-args-options

Fixes #143 