### PR TITLE
Record `tsc` compiled code

### DIFF
--- a/components/agent/default/source-map.test.mjs
+++ b/components/agent/default/source-map.test.mjs
@@ -1,4 +1,5 @@
 import { writeFile as writeFileAsync } from "node:fs/promises";
+import { Buffer } from "node:buffer";
 import { assertEqual } from "../../__fixture__.mjs";
 import { getUuid } from "../../uuid/random/index.mjs";
 import { getTmpUrl } from "../../path/index.mjs";
@@ -8,6 +9,7 @@ import { mapSource } from "../../source/index.mjs";
 import { loadSourceMap } from "./source-map.mjs";
 
 const {
+  Boolean,
   encodeURIComponent,
   URL,
   JSON: { stringify: stringifyJSON },
@@ -101,6 +103,64 @@ assertEqual(
       {
         url: "http://host/main.js",
         content: `123; //# sourceMappingURL=${url}`,
+      },
+      null,
+    ),
+    456,
+    789,
+  ),
+  null,
+);
+
+const inlineSourceMapData = Buffer.from(
+  stringifyJSON({
+    version: 3,
+    sources: ["http://host/main.js"],
+    mappings: "CACCA;",
+    names: ["nop"],
+  }),
+  "utf-8",
+).toString("base64");
+
+const buildInlineSourceMap = (mediaType, encoding, data) =>
+  ["data:", mediaType, encoding && `;${encoding}`, ",", data]
+    .filter(Boolean)
+    .join("");
+
+// Proper handling of inline source maps.
+assertEqual(
+  mapSource(
+    loadSourceMap(
+      {
+        url: "http://host/main.js",
+        content: `() => {}; //# sourceMappingURL=${buildInlineSourceMap(
+          "application/json",
+          "base64",
+          inlineSourceMapData,
+        )}`,
+      },
+      null,
+    ),
+    1,
+    1,
+  ),
+  makeLocation("http://host/main.js", {
+    line: 2, // TODO: This is off by one. It should be 1, not 2.
+    column: 1,
+  }),
+);
+
+// Invalid encoding should be rejected, returning null.
+assertEqual(
+  mapSource(
+    loadSourceMap(
+      {
+        url: "http://host/main.js",
+        content: `123; //# sourceMappingURL=${buildInlineSourceMap(
+          "image/png",
+          "base64",
+          inlineSourceMapData,
+        )}`,
       },
       null,
     ),

--- a/components/trace/appmap/classmap/source.mjs
+++ b/components/trace/appmap/classmap/source.mjs
@@ -45,11 +45,9 @@ export const createSource = (
     content,
   };
   const entities = wrapRootEntityArray(
-    digestEstreeRoot(estree, context).flatMap((entity) =>
-      excludeEntity(entity, null, getExclusion),
-    ),
+    digestEstreeRoot(estree, context),
     context,
-  );
+  ).flatMap((entity) => excludeEntity(entity, null, getExclusion));
   const infos = new Map();
   for (const entity of entities) {
     registerFunctionEntity(entity, null, infos);

--- a/components/trace/appmap/classmap/source.test.mjs
+++ b/components/trace/appmap/classmap/source.test.mjs
@@ -36,8 +36,8 @@ assertDeepEqual(
       exclusions: [
         {
           combinator: "or",
-          name: "g",
-          "qualified-name": false,
+          name: false,
+          "qualified-name": "^basename\\.g$",
           "some-label": false,
           "every-label": false,
           excluded: true,


### PR DESCRIPTION
This fixes an issue found while trying to record @appland/scanner and adds some additional test cases.

Resolves #173 