### PR TITLE
fix: wrap root function before exclusion

### DIFF
--- a/components/trace/appmap/classmap/source.mjs
+++ b/components/trace/appmap/classmap/source.mjs
@@ -45,11 +45,9 @@ export const createSource = (
     content,
   };
   const entities = wrapRootEntityArray(
-    digestEstreeRoot(estree, context).flatMap((entity) =>
-      excludeEntity(entity, null, getExclusion),
-    ),
+    digestEstreeRoot(estree, context),
     context,
-  );
+  ).flatMap((entity) => excludeEntity(entity, null, getExclusion));
   const infos = new Map();
   for (const entity of entities) {
     registerFunctionEntity(entity, null, infos);

--- a/components/trace/appmap/classmap/source.test.mjs
+++ b/components/trace/appmap/classmap/source.test.mjs
@@ -36,8 +36,8 @@ assertDeepEqual(
       exclusions: [
         {
           combinator: "or",
-          name: "g",
-          "qualified-name": false,
+          name: false,
+          "qualified-name": "^basename\\.g$",
           "some-label": false,
           "every-label": false,
           excluded: true,


### PR DESCRIPTION
Qualified name is required to exclude functions. And computing the  qualified name assumes that there is no functions at the root level. So  we need to wrap root level functions before exclusion.