### PR TITLE
fix: support concurrent jest test case

### DIFF
--- a/components/recorder-cli/default/jest.mjs
+++ b/components/recorder-cli/default/jest.mjs
@@ -1,5 +1,5 @@
 import { ExternalAppmapError } from "../../error/index.mjs";
-import { logErrorWhen } from "../../log/index.mjs";
+import { logErrorWhen, logWarningWhen } from "../../log/index.mjs";
 import { getUuid } from "../../uuid/index.mjs";
 import { hook } from "../../hook/index.mjs";
 import { extendConfiguration } from "../../configuration/index.mjs";
@@ -9,6 +9,18 @@ import {
   recordStartTrack,
   recordStopTrack,
 } from "../../agent/index.mjs";
+
+const {
+  Map,
+  Array: { from: toArray },
+  Reflect: { defineProperty },
+} = globalThis;
+
+const getName = ({ name }) => name;
+
+function showTrackMap() {
+  return toArray(this.values()).map(getName);
+}
 
 export const record = (configuration) => {
   // I would prefer to use require rather that global variable:
@@ -39,48 +51,67 @@ export const record = (configuration) => {
   }
   const { beforeEach, afterEach, expect } = globalThis;
   const agent = openAgent(configuration);
+  // Jest is claiming that it is running the tests from a given file serially.
+  // However we detected nested calls of beforeEach / afterEach in practice.
+  // So we need to maintain a set of track ids instead of a single one.
+  const tracks = new Map();
+  defineProperty(tracks, "toJSON", {
+    __proto__: null,
+    writable: true,
+    configurable: true,
+    enumerable: true,
+    value: showTrackMap,
+  });
   hook(agent, configuration);
-  let track = null;
-  beforeEach(() => {
+  beforeEach(function () {
     assert(
       !logErrorWhen(
-        track !== null,
-        "Detected concurrent jest test cases %j",
-        track,
+        tracks.has(this),
+        "Duplicate beforeEach test context %o in %j",
+        this,
+        tracks,
       ),
-      "Concurrent jest test cases",
       ExternalAppmapError,
+      "Duplicate beforeEach test context",
     );
     // We cannot use a counter because another jest
     // agent may be running in a different context.
-    track = `jest-${getUuid()}`;
+    const track = `jest-${getUuid()}`;
+    const name = expect.getState().currentTestName;
+    tracks.set(this, { track, name });
+    logWarningWhen(
+      tracks.size > 1,
+      "Detected concurrent jest tests (beforeEach): %j",
+      tracks,
+    );
     recordStartTrack(
       agent,
       track,
-      extendConfiguration(
-        configuration,
-        {
-          "map-name": expect.getState().currentTestName,
-        },
-        null,
-      ),
+      extendConfiguration(configuration, { "map-name": name }, null),
     );
   });
-  afterEach(() => {
+  afterEach(function () {
     assert(
       !logErrorWhen(
-        track === null,
-        "Detected concurrent jest test cases %j",
-        track,
+        !tracks.has(this),
+        "Missing afterEach test context %o in %j",
+        this,
+        tracks,
       ),
-      "Concurrent jest test cases",
       ExternalAppmapError,
+      "Missing after test context",
     );
+    logWarningWhen(
+      tracks.size > 1,
+      "Detected concurrent jest tests (afterEach): %j",
+      tracks,
+    );
+    const { track } = tracks.get(this);
+    tracks.delete(this);
     recordStopTrack(agent, track, {
       type: "test",
       // TODO: figure out how to fetch the status of the current test case
       passed: true,
     });
-    track = null;
   });
 };


### PR DESCRIPTION
Jest is claiming that it is running the tests from a given file  serially. However we detected nested calls of `beforeEach` and  `afterEach` in one of our user. So, instead of crashing, we maintain a  mapping of track ids.