### PR TITLE
Fix collision of source urls

### DIFF
--- a/components/.ordering
+++ b/components/.ordering
@@ -9,6 +9,7 @@ log-inner
 log
 validate
 validate-appmap
+hash
 patch
 peer
 file

--- a/components/agent/default/index.test.mjs
+++ b/components/agent/default/index.test.mjs
@@ -59,9 +59,6 @@ assertDeepEqual(takeLocalAgentTrace(agent, "record"), [
     type: "source",
     url: "protocol://host/base/main.js",
     content: "123;",
-    exclude: createConfiguration("protocol://host/home").exclude,
-    shallow: false,
-    inline: false,
   },
   {
     type: "start",

--- a/components/agent/default/source-map.test.mjs
+++ b/components/agent/default/source-map.test.mjs
@@ -142,6 +142,7 @@ assertDeepEqual(
   ),
   {
     url: "http://host/main.js",
+    hash: null,
     line: 2, // TODO: This is off by one. It should be 1, not 2.
     column: 1,
   },

--- a/components/agent/default/source-map.test.mjs
+++ b/components/agent/default/source-map.test.mjs
@@ -4,7 +4,6 @@ import { assertEqual } from "../../__fixture__.mjs";
 import { getUuid } from "../../uuid/random/index.mjs";
 import { getTmpUrl } from "../../path/index.mjs";
 import { toAbsoluteUrl } from "../../url/index.mjs";
-import { makeLocation } from "../../location/index.mjs";
 import { mapSource } from "../../source/index.mjs";
 import { loadSourceMap } from "./source-map.mjs";
 
@@ -27,10 +26,10 @@ assertEqual(
     456,
     789,
   ),
-  makeLocation("http://host/main.js", {
+  {
     line: 456,
     column: 789,
-  }),
+  },
 );
 
 const mapping = {
@@ -89,10 +88,11 @@ assertEqual(
     456,
     789,
   ),
-  makeLocation("http://host/main.js", {
+  {
+    url: "http://host/main.js",
     line: 456,
     column: 789,
-  }),
+  },
 );
 
 await writeFileAsync(new URL(url), stringifyJSON(mapping), "utf8");
@@ -128,7 +128,7 @@ const buildInlineSourceMap = (mediaType, encoding, data) =>
     .join("");
 
 // Proper handling of inline source maps.
-assertEqual(
+assertDeepEqual(
   mapSource(
     loadSourceMap(
       {
@@ -144,10 +144,11 @@ assertEqual(
     1,
     1,
   ),
-  makeLocation("http://host/main.js", {
+  {
+    url: "http://host/main.js",
     line: 2, // TODO: This is off by one. It should be 1, not 2.
     column: 1,
-  }),
+  },
 );
 
 // Invalid encoding should be rejected, returning null.

--- a/components/configuration-accessor/default/index.mjs
+++ b/components/configuration-accessor/default/index.mjs
@@ -15,7 +15,7 @@ import {
   extractRepositoryHistory,
   extractRepositoryPackage,
 } from "../../repository/index.mjs";
-import { matchSpecifier } from "../../specifier/index.mjs";
+import { lookupSpecifier } from "../../specifier/index.mjs";
 import { extendConfiguration } from "../../configuration/index.mjs";
 import { resolveShell } from "./escape.mjs";
 import { tokenize } from "./tokenize.mjs";
@@ -40,15 +40,6 @@ const {
   Object: { entries: toEntries },
   JSON: { stringify: stringifyJSON },
 } = globalThis;
-
-const getSpecifierValue = (pairs, key, def) => {
-  for (const [specifier, value] of pairs) {
-    if (matchSpecifier(specifier, key)) {
-      return value;
-    }
-  }
-  return def;
-};
 
 export const resolveConfigurationRepository = (configuration) => {
   assert(
@@ -214,12 +205,12 @@ export const isConfigurationEnabled = ({
   processes,
   main,
   "default-process": default_process,
-}) => main === null || getSpecifierValue(processes, main, default_process);
+}) => main === null || lookupSpecifier(processes, main, default_process);
 
 export const getConfigurationPackage = (
   { packages, "default-package": default_package },
   url,
-) => getSpecifierValue(packages, url, default_package);
+) => lookupSpecifier(packages, url, default_package);
 
 const compileScenario = (scenario) => {
   try {

--- a/components/frontend/default/index.test.mjs
+++ b/components/frontend/default/index.test.mjs
@@ -67,9 +67,6 @@ validateMessage(formatBeginAmend(frontend, 123, getBundlePayload(frontend)));
         type: "source",
         url: "protocol://host/filename.js",
         content: "123;",
-        exclude: createConfiguration("protocol://host/home").exclude,
-        shallow: false,
-        inline: false,
       },
     ],
   });

--- a/components/hash/node/.env
+++ b/components/hash/node/.env
@@ -1,0 +1,2 @@
+node
+test

--- a/components/hash/node/index.mjs
+++ b/components/hash/node/index.mjs
@@ -1,0 +1,9 @@
+import { createHash } from "node:crypto";
+
+export const hashFile = ({ url, content }) => {
+  const hash = createHash("sha256");
+  hash.update(url, "utf8");
+  hash.update("\0", "utf8");
+  hash.update(content, "utf8");
+  return hash.digest("base64");
+};

--- a/components/hash/node/index.test.mjs
+++ b/components/hash/node/index.test.mjs
@@ -1,0 +1,10 @@
+import { assertEqual, assertNotEqual } from "../../__fixture__.mjs";
+import { hashFile } from "./index.mjs";
+
+const file = { url: "protocol://host/path", content: "content" };
+
+assertEqual(typeof hashFile(file), "string");
+
+assertEqual(hashFile(file), hashFile(file));
+
+assertNotEqual(hashFile(file), hashFile({ ...file, content: "CONTENT" }));

--- a/components/hook-eval/default/index.mjs
+++ b/components/hook-eval/default/index.mjs
@@ -6,7 +6,6 @@
 // }};
 
 import { toAbsoluteUrl, toDirectoryUrl } from "../../url/index.mjs";
-import { getUuid } from "../../uuid/index.mjs";
 import { InternalAppmapError } from "../../error/index.mjs";
 import { assert, hasOwnProperty } from "../../util/index.mjs";
 import { instrument } from "../../agent/index.mjs";
@@ -55,18 +54,14 @@ export const hook = (
       writable: false,
       enumerable: false,
       configurable: true,
-      value: (url, location, content) =>
+      value: (url, position, content) =>
         instrument(
           agent,
           {
-            // We need to use a unique filename because
-            // a single eval call location may evaluate
-            // multiple different code.
-            url: toAbsoluteUrl(
-              `eval-${location}-${getUuid()}.js`,
-              toDirectoryUrl(url),
-            ),
             type: "script",
+            // We do not need to use a unique filename
+            // because we support dynamic sources.
+            url: toAbsoluteUrl(`eval-${position}.js`, toDirectoryUrl(url)),
             content: String(content),
           },
           null,

--- a/components/hook-eval/default/index.test.mjs
+++ b/components/hook-eval/default/index.test.mjs
@@ -29,7 +29,7 @@ assertDeepEqual(
   [
     {
       type: "source",
-      url: "protocol://host/foo/eval-123-456-uuid.js",
+      url: "protocol://host/foo/eval-123-456.js",
       content: "789;",
     },
   ],

--- a/components/hook-eval/default/index.test.mjs
+++ b/components/hook-eval/default/index.test.mjs
@@ -1,5 +1,4 @@
 import { assertEqual, assertDeepEqual } from "../../__fixture__.mjs";
-import { createConfiguration } from "../../configuration/index.mjs";
 import { testHookAsync } from "../../hook-fixture/index.mjs";
 import * as HookEval from "./index.mjs";
 
@@ -14,7 +13,7 @@ assertDeepEqual(
         packages: [
           {
             regexp: "^",
-            shallow: true,
+            enabled: true,
           },
         ],
       },
@@ -32,9 +31,6 @@ assertDeepEqual(
       type: "source",
       url: "protocol://host/foo/eval-123-456-uuid.js",
       content: "789;",
-      shallow: true,
-      exclude: createConfiguration("protocol://host/home").exclude,
-      inline: false,
     },
   ],
 );

--- a/components/hook-module/node/cjs.test.mjs
+++ b/components/hook-module/node/cjs.test.mjs
@@ -8,7 +8,6 @@ import { assertEqual, assertDeepEqual } from "../../__fixture__.mjs";
 import { getUuid } from "../../uuid/random/index.mjs";
 import { getTmpUrl, convertPathToFileUrl } from "../../path/index.mjs";
 import { toAbsoluteUrl } from "../../url/index.mjs";
-import { createConfiguration } from "../../configuration/index.mjs";
 import { testHookAsync } from "../../hook-fixture/index.mjs";
 import * as HookCjs from "./cjs.mjs";
 
@@ -54,7 +53,7 @@ assertDeepEqual(
         packages: [
           {
             regexp: "^",
-            shallow: true,
+            enabled: true,
           },
         ],
       },
@@ -69,9 +68,6 @@ assertDeepEqual(
       type: "source",
       url: convertPathToFileUrl(await realpathAsync(new URL(url))),
       content: "module.exports = 123;",
-      exclude: createConfiguration("protocol://host/home").exclude,
-      shallow: true,
-      inline: false,
     },
   ],
 );

--- a/components/hook-module/node/esm.test.mjs
+++ b/components/hook-module/node/esm.test.mjs
@@ -1,6 +1,5 @@
 import { hooks } from "../../../lib/node/loader-esm.mjs";
 import { assertEqual, assertDeepEqual } from "../../__fixture__.mjs";
-import { createConfiguration } from "../../configuration/index.mjs";
 import { testHookAsync } from "../../hook-fixture/index.mjs";
 import * as HookEsm from "./esm.mjs";
 
@@ -15,7 +14,7 @@ assertDeepEqual(
         packages: [
           {
             regexp: "^",
-            shallow: true,
+            enabled: true,
           },
         ],
       },
@@ -64,17 +63,11 @@ assertDeepEqual(
       type: "source",
       url: "protocol://host/foo",
       content: "123;",
-      shallow: true,
-      exclude: createConfiguration("protocol://host/home").exclude,
-      inline: false,
     },
     {
       type: "source",
       url: "protocol://host/bar",
       content: "456;",
-      shallow: true,
-      exclude: createConfiguration("protocol://host/home").exclude,
-      inline: false,
     },
   ],
 );

--- a/components/instrumentation/default/index.mjs
+++ b/components/instrumentation/default/index.mjs
@@ -18,7 +18,6 @@ const getURL = generateGet("url");
 
 export const createInstrumentation = (configuration) => ({
   configuration,
-  done: new Set(),
 });
 
 const parseEstree = (type, content, url) => {
@@ -37,7 +36,7 @@ const parseEstree = (type, content, url) => {
 };
 
 export const instrument = (
-  { configuration, done },
+  { configuration },
   { url, type, content },
   mapping,
 ) => {
@@ -74,10 +73,6 @@ export const instrument = (
     );
     return { url, content, sources: [] };
   } else {
-    const new_sources = sources.filter(({ url }) => !done.has(url));
-    for (const { url } of new_sources) {
-      done.add(url);
-    }
     if (
       configuration.hooks.eval.aliases.length === 0 &&
       configuration.hooks.apply === null
@@ -86,7 +81,7 @@ export const instrument = (
         "Not instrumenting file %j because instrumentation hooks (apply and eval) are disabled",
         url,
       );
-      return { url, content, sources: new_sources };
+      return { url, content, sources };
     } else {
       logDebug("Instrumenting file %j", url);
       return {
@@ -100,7 +95,7 @@ export const instrument = (
             mapping,
           }),
         ),
-        sources: new_sources,
+        sources,
       };
     }
   }

--- a/components/instrumentation/default/index.mjs
+++ b/components/instrumentation/default/index.mjs
@@ -2,9 +2,9 @@ import * as Astring from "astring";
 import * as Acorn from "acorn";
 import { logError, logDebug } from "../../log/index.mjs";
 import { generateGet, recoverMaybe } from "../../util/index.mjs";
-import { getConfigurationPackage } from "../../configuration-accessor/index.mjs";
 import { ExternalAppmapError } from "../../error/index.mjs";
 import { getSources } from "../../source/index.mjs";
+import { lookupSpecifier } from "../../specifier/index.mjs";
 import { visit } from "./visit.mjs";
 
 const { Set } = globalThis;
@@ -48,7 +48,7 @@ export const instrument = (
         shallow,
         exclude,
         "inline-source": inline,
-      } = getConfigurationPackage(configuration, url);
+      } = lookupSpecifier(configuration, url);
       logDebug(
         "%s source file %j",
         enabled ? "Instrumenting" : "Not instrumenting",

--- a/components/instrumentation/default/index.mjs
+++ b/components/instrumentation/default/index.mjs
@@ -42,12 +42,11 @@ export const instrument = (
 ) => {
   const sources = getSources(mapping)
     .map(({ url, content }) => {
-      const {
-        enabled,
-        shallow,
-        exclude,
-        "inline-source": inline,
-      } = lookupSpecifier(configuration, url);
+      const { enabled } = lookupSpecifier(
+        configuration.packages,
+        url,
+        configuration["default-package"],
+      );
       logDebug(
         "%s source file %j",
         enabled ? "Instrumenting" : "Not instrumenting",
@@ -58,9 +57,6 @@ export const instrument = (
         body: {
           url,
           content,
-          shallow,
-          inline: recoverMaybe(inline, configuration["inline-source"]),
-          exclude: [...exclude, ...configuration.exclude],
         },
       };
     })

--- a/components/instrumentation/default/index.mjs
+++ b/components/instrumentation/default/index.mjs
@@ -1,7 +1,7 @@
 import * as Astring from "astring";
 import * as Acorn from "acorn";
 import { logError, logDebug } from "../../log/index.mjs";
-import { generateGet, recoverMaybe } from "../../util/index.mjs";
+import { generateGet } from "../../util/index.mjs";
 import { ExternalAppmapError } from "../../error/index.mjs";
 import { getSources } from "../../source/index.mjs";
 import { lookupSpecifier } from "../../specifier/index.mjs";
@@ -14,7 +14,7 @@ const { parse: parseAcorn } = Acorn;
 
 const getHead = generateGet("head");
 const getBody = generateGet("body");
-const getURL = generateGet("url");
+const getUrl = generateGet("url");
 
 export const createInstrumentation = (configuration) => ({
   configuration,
@@ -89,7 +89,7 @@ export const instrument = (
         content: generateEstree(
           visit(parseEstree(type, content, url), {
             url,
-            whitelist: new Set(sources.map(getURL)),
+            whitelist: new Set(sources.map(getUrl)),
             eval: configuration.hooks.eval,
             apply: configuration.hooks.apply,
             mapping,

--- a/components/instrumentation/default/index.test.mjs
+++ b/components/instrumentation/default/index.test.mjs
@@ -7,25 +7,6 @@ import {
 import { normalize } from "./__fixture__.mjs";
 import { createInstrumentation, instrument } from "./index.mjs";
 
-const and_exclusion = {
-  combinator: "and",
-  name: true,
-  "qualified-name": true,
-  "every-label": true,
-  "some-label": true,
-  excluded: false,
-  recursive: false,
-};
-
-const makeExclusion = (name) => ({
-  ...and_exclusion,
-  "qualified-name": name,
-  excluded: true,
-  recursive: true,
-});
-
-const default_exclude = createConfiguration("protocol://host/home").exclude;
-
 const normalizeContent = ({ content, ...rest }, source) => ({
   content: normalize(content, source),
   ...rest,
@@ -81,9 +62,6 @@ const normalizeContent = ({ content, ...rest }, source) => ({
               {
                 path: "script.js",
                 enabled: true,
-                exclude: [],
-                shallow: true,
-                "inline-source": true,
               },
             ],
           },
@@ -100,9 +78,6 @@ const normalizeContent = ({ content, ...rest }, source) => ({
         {
           url: "protocol://host/base/script.js",
           content: "function main () {}",
-          shallow: true,
-          inline: true,
-          exclude: default_exclude,
         },
       ],
     },
@@ -154,13 +129,6 @@ const instrumentation = createInstrumentation(
         {
           url: "protocol://host/base/foo.js",
           content: "123;",
-          shallow: true,
-          inline: true,
-          exclude: [
-            makeExclusion("foo"),
-            makeExclusion("qux"),
-            ...default_exclude,
-          ],
         },
       ],
     },

--- a/components/instrumentation/default/visit.test.mjs
+++ b/components/instrumentation/default/visit.test.mjs
@@ -1,5 +1,5 @@
 import { assertEqual } from "../../__fixture__.mjs";
-import { makeLocation } from "../../location/index.mjs";
+import { stringifyLocation } from "../../location/index.mjs";
 import { createCounter } from "../../util/index.mjs";
 import { createMirrorSourceMap } from "../../source/index.mjs";
 import { normalize, parse, generate } from "./__fixture__.mjs";
@@ -31,7 +31,9 @@ const instrument = (file, whitelist) =>
   );
 
 const makeCodeLocation = (url, line, column) =>
-  stringifyJSON(makeLocation(url, { line, column }));
+  stringifyJSON(
+    stringifyLocation({ url, line, column }),
+  );
 
 // expression body //
 assertEqual(

--- a/components/location/default/index.mjs
+++ b/components/location/default/index.mjs
@@ -5,14 +5,18 @@ const { String, parseInt } = globalThis;
 
 const regexp = /^([\s\S]+)#([0-9]+)-([0-9]+)$/u;
 
-export const stringifyLocation = ({ url, line, column }) =>
-  `${url}#${String(line)}-${String(column)}`;
+export const stringifyLocation = ({ url, hash, line, column }) =>
+  // Prefer hash location over url location to support dynamic sources.
+  `${hash === null ? url : hash}#${String(line)}-${String(column)}`;
 
 export const parseLocation = (string) => {
   const parts = regexp.exec(string);
   assert(parts !== null, InternalAppmapError, "invalid location format");
+  // Hash is base64-encoded and cannot contain `:`.
+  const is_url_based = parts[1].includes(":");
   return {
-    url: parts[1],
+    url: is_url_based ? parts[1] : null,
+    hash: is_url_based ? null : parts[1],
     line: parseInt(parts[2]),
     column: parseInt(parts[3]),
   };

--- a/components/location/default/index.mjs
+++ b/components/location/default/index.mjs
@@ -1,23 +1,19 @@
 import { InternalAppmapError } from "../../error/index.mjs";
 import { assert } from "../../util/index.mjs";
 
-const { URL, String, parseInt } = globalThis;
+const { String, parseInt } = globalThis;
 
-export const makeLocation = (url, { line, column }) =>
-  new URL(`#${String(line)}-${String(column)}`, url).toString();
+const regexp = /^([\s\S]+)#([0-9]+)-([0-9]+)$/u;
 
-export const getLocationPosition = (url) => {
-  const { hash } = new URL(url);
-  const parts = /^#([0-9]+)-([0-9]+)$/u.exec(hash);
-  assert(parts !== null, "expected a url code location", InternalAppmapError);
+export const stringifyLocation = ({ url, line, column }) =>
+  `${url}#${String(line)}-${String(column)}`;
+
+export const parseLocation = (string) => {
+  const parts = regexp.exec(string);
+  assert(parts !== null, InternalAppmapError, "invalid location format");
   return {
-    line: parseInt(parts[1]),
-    column: parseInt(parts[2]),
+    url: parts[1],
+    line: parseInt(parts[2]),
+    column: parseInt(parts[3]),
   };
-};
-
-export const getLocationBase = (url) => {
-  const object_url = new URL(url);
-  object_url.hash = "";
-  return object_url.toString();
 };

--- a/components/location/default/index.test.mjs
+++ b/components/location/default/index.test.mjs
@@ -1,14 +1,6 @@
-import { assertEqual, assertDeepEqual } from "../../__fixture__.mjs";
-import {
-  makeLocation,
-  getLocationPosition,
-  getLocationBase,
-} from "./index.mjs";
+import { assertDeepEqual } from "../../__fixture__.mjs";
+import { stringifyLocation, parseLocation } from "./index.mjs";
 
-const base = "protocol://host/path";
-const position = { line: 123, column: 456 };
-const location = makeLocation(base, position);
+const location = { url: "protocol://host/path", line: 123, column: 456 };
 
-assertDeepEqual(getLocationPosition(location), position);
-
-assertEqual(getLocationBase(location), base);
+assertDeepEqual(parseLocation(stringifyLocation(location)), location);

--- a/components/location/default/index.test.mjs
+++ b/components/location/default/index.test.mjs
@@ -1,6 +1,10 @@
 import { assertDeepEqual } from "../../__fixture__.mjs";
 import { stringifyLocation, parseLocation } from "./index.mjs";
 
-const location = { url: "protocol://host/path", line: 123, column: 456 };
+const test = (location) => {
+  assertDeepEqual(parseLocation(stringifyLocation(location)), location);
+};
 
-assertDeepEqual(parseLocation(stringifyLocation(location)), location);
+test({ hash: "hash", url: null, line: 123, column: 456 });
+
+test({ hash: null, url: "protocol://host/path", line: 123, column: 456 });

--- a/components/recorder-api/default/index.test.mjs
+++ b/components/recorder-api/default/index.test.mjs
@@ -46,9 +46,6 @@ assertDeepEqual(appmap.stopRecording(track), [
     type: "source",
     url: "protocol://host/base/main.js",
     content: "123;",
-    exclude: createConfiguration("protocol://host/home/").exclude,
-    shallow: false,
-    inline: false,
   },
   {
     type: "source",

--- a/components/recorder-api/default/index.test.mjs
+++ b/components/recorder-api/default/index.test.mjs
@@ -51,6 +51,11 @@ assertDeepEqual(appmap.stopRecording(track), [
     inline: false,
   },
   {
+    type: "source",
+    url: "protocol://host/base/main.js",
+    content: "123;",
+  },
+  {
     type: "start",
     track: "uuid",
     configuration: { ...configuration, name: "name2" },

--- a/components/source/default/index.mjs
+++ b/components/source/default/index.mjs
@@ -5,7 +5,6 @@ import {
 } from "../../error/index.mjs";
 import { toDirectoryUrl, toAbsoluteUrl } from "../../url/index.mjs";
 import { logInfo, logError } from "../../log/index.mjs";
-import { makeLocation } from "../../location/index.mjs";
 import { validateSourceMap } from "../../validate/index.mjs";
 
 const {
@@ -106,16 +105,18 @@ export const createSourceMap = ({ url: base, content }) => {
 
 export const mapSource = (mapping, line, column) => {
   if (mapping.type === "mirror") {
-    return makeLocation(mapping.source.url, { line, column });
+    return { url: mapping.source.url, line, column };
   } else if (mapping.type === "normal") {
     if (line <= mapping.lines.length) {
       for (const fields of mapping.lines[line - 1]) {
         if (fields[0] === column && fields.length >= 4) {
           if (fields[1] < mapping.sources.length) {
-            return makeLocation(mapping.sources[fields[1]].url, {
+            const source = mapping.sources[fields[1]];
+            return {
+              url: source.url,
               line: fields[2] + 1,
               column: fields[3],
-            });
+            };
           } else {
             logInfo(
               "Source map out of range at file %j, line %j, and column %j",

--- a/components/source/default/index.test.mjs
+++ b/components/source/default/index.test.mjs
@@ -5,6 +5,7 @@ import {
   assertDeepEqual,
   assertThrow,
 } from "../../__fixture__.mjs";
+import { hashFile } from "../../hash/index.mjs";
 import {
   extractSourceMapUrl,
   createMirrorSourceMap,
@@ -57,11 +58,15 @@ assertEqual(
 ////////////
 
 {
-  const mapping = createMirrorSourceMap({
+  const file = {
     url: "http://host/out.js",
     content: "123;",
+  };
+  const hash = hashFile(file);
+  const mapping = createMirrorSourceMap(file);
   assertDeepEqual(mapSource(mapping, 123, 456), {
     url: file.url,
+    hash,
     line: 123,
     column: 456,
   });
@@ -92,13 +97,17 @@ assertEqual(
   });
   assertDeepEqual(mapSource(mapping, 3, 13), {
     url: "http://host/directory/source.js",
+    hash: null,
     line: 17,
     column: 19,
   });
   assertEqual(mapSource(mapping, 3, 23), null);
   assertEqual(mapSource(mapping, 29, 0), null);
   assertDeepEqual(getSources(mapping), [
-    { url: "http://host/directory/source.js", content: null },
+    {
+      url: "http://host/directory/source.js",
+      content: null,
+    },
   ]);
 }
 
@@ -134,8 +143,14 @@ assertDeepEqual(
     }),
   ),
   [
-    { url: "http://host/directory/root/source1.js", content: "123;" },
-    { url: "http://host/directory/root/source2.js", content: null },
+    {
+      url: "http://host/directory/root/source1.js",
+      content: "123;",
+    },
+    {
+      url: "http://host/directory/root/source2.js",
+      content: null,
+    },
   ],
 );
 
@@ -151,5 +166,10 @@ assertDeepEqual(
       },
     }),
   ),
-  [{ url: "http://host/directory/source.js", content: null }],
+  [
+    {
+      url: "http://host/directory/source.js",
+      content: null,
+    },
+  ],
 );

--- a/components/source/default/index.test.mjs
+++ b/components/source/default/index.test.mjs
@@ -5,7 +5,6 @@ import {
   assertDeepEqual,
   assertThrow,
 } from "../../__fixture__.mjs";
-import { makeLocation } from "../../location/index.mjs";
 import {
   extractSourceMapUrl,
   createMirrorSourceMap,
@@ -61,8 +60,11 @@ assertEqual(
   const mapping = createMirrorSourceMap({
     url: "http://host/out.js",
     content: "123;",
+  assertDeepEqual(mapSource(mapping, 123, 456), {
+    url: file.url,
+    line: 123,
+    column: 456,
   });
-  assertEqual(mapSource(mapping, 123, 456), "http://host/out.js#123-456");
   assertDeepEqual(getSources(mapping), [
     { url: "http://host/out.js", content: "123;" },
   ]);
@@ -88,10 +90,11 @@ assertEqual(
     url: "http://host/directory/map.json",
     content: generator.toString(),
   });
-  assertEqual(
-    mapSource(mapping, 3, 13),
-    makeLocation("http://host/directory/source.js", { line: 17, column: 19 }),
-  );
+  assertDeepEqual(mapSource(mapping, 3, 13), {
+    url: "http://host/directory/source.js",
+    line: 17,
+    column: 19,
+  });
   assertEqual(mapSource(mapping, 3, 23), null);
   assertEqual(mapSource(mapping, 29, 0), null);
   assertDeepEqual(getSources(mapping), [

--- a/components/specifier/default/index.mjs
+++ b/components/specifier/default/index.mjs
@@ -142,3 +142,12 @@ export const matchSpecifier = (specifier, url) => {
     return matched;
   }
 };
+
+export const lookupSpecifier = (entries, url, default_value) => {
+  for (const [specifier, value] of entries) {
+    if (matchSpecifier(specifier, url)) {
+      return value;
+    }
+  }
+  return default_value;
+};

--- a/components/specifier/default/index.test.mjs
+++ b/components/specifier/default/index.test.mjs
@@ -1,5 +1,5 @@
 import { assertEqual, assertThrow } from "../../__fixture__.mjs";
-import { createSpecifier, matchSpecifier } from "./index.mjs";
+import { createSpecifier, matchSpecifier, lookupSpecifier } from "./index.mjs";
 
 const { encodeURIComponent } = globalThis;
 
@@ -209,4 +209,27 @@ assertEqual(
     "protocol://host/node_modules/dist/file.ext",
   ),
   true,
+);
+
+/////////////////////
+// lookupSpecifier //
+/////////////////////
+
+assertEqual(
+  lookupSpecifier([], "protocol://host/base/file.ext", "default_value"),
+  "default_value",
+);
+
+assertEqual(
+  lookupSpecifier(
+    [
+      [
+        createSpecifier({ regexp: "^file\\." }, "protocol://host/base/"),
+        "value",
+      ],
+    ],
+    "protocol://host/base/file.ext",
+    "default_value",
+  ),
+  "value",
 );

--- a/components/trace/appmap/.ordering
+++ b/components/trace/appmap/.ordering
@@ -2,5 +2,5 @@ classmap
 event
 ordering
 metadata.mjs
-location.mjs
+output.mjs
 index.mjs

--- a/components/trace/appmap/classmap/index.mjs
+++ b/components/trace/appmap/classmap/index.mjs
@@ -1,21 +1,41 @@
-import { InternalAppmapError } from "../../../error/index.mjs";
 import { assert } from "../../../util/index.mjs";
-import { toRelativeUrl } from "../../../url/index.mjs";
-import { logWarning } from "../../../log/index.mjs";
+import { InternalAppmapError } from "../../../error/index.mjs";
 import { lookupSpecifier } from "../../../specifier/index.mjs";
+import { hashFile } from "../../../hash/index.mjs";
 import {
+  getUrlFilename,
+  toAbsoluteUrl,
+  toRelativeUrl,
+} from "../../../url/index.mjs";
+import { logWarning } from "../../../log/index.mjs";
 import {
   createSource,
   toSourceClassmap,
   lookupSourceClosure,
+  getSourceRelativeUrl,
 } from "./source.mjs";
 
-const { Map } = globalThis;
+const { String, Map } = globalThis;
 
 export const createClassmap = (configuration) => ({
-  sources: new Map(),
   configuration,
+  // Mapping from the hash of a file (url + content) to the associated source
+  // object.
+  sources: new Map(),
+  // Mapping from url to counter to provide unique relative urls for function
+  // entities.
+  urls: new Map(),
+  // Mapping from url to file hash to support url-based lookup. When a url is
+  // mapped to null, it means that there is multiple different content for that
+  // url. In other words, the source is dynamic.
+  indirections: new Map(),
 });
+
+const toDynamicRelativeUrl = (url, index, base) =>
+  toRelativeUrl(
+    toAbsoluteUrl(`${getUrlFilename(url)}#${String(index)}`, url),
+    base,
+  );
 
 export const addClassmapSource = (
   {
@@ -29,47 +49,107 @@ export const addClassmapSource = (
       "inline-source": global_inline_source,
     },
     sources,
+    indirections,
+    urls,
   },
-  { url, content, inline, exclude: exclusions, shallow },
+  { url, content },
 ) => {
-  assert(!sources.has(url), "duplicate source url", InternalAppmapError);
-  const {
-    "inline-source": local_inline_source,
-    exclude: local_exclusion_array,
-    shallow,
-  } = lookupSpecifier(specifiers, url, default_specifier);
-  sources.set(
-    hash,
-    createSource(content, {
   let relative = toRelativeUrl(url, directory);
   if (relative === null) {
     logWarning(
       "Ignoring %j because it could not be expressed relatively to %j",
       url,
-      relative,
-      placeholder,
-      pruning,
-      inline: local_inline_source ?? global_inline_source,
-      exclusions: [...global_exclusion_array, ...local_exclusion_array],
-      shallow,
-    }),
-  );
+      directory,
+    );
   } else if (content === null) {
     logWarning("Ignoring %j because its content could not be loaded", url);
+    indirections.set(url, null);
+  } else {
+    const hash = hashFile({ url, content });
+    if (!sources.has(hash)) {
+      const {
+        "inline-source": local_inline_source,
+        exclude: local_exclusion_array,
+        shallow,
+      } = lookupSpecifier(specifiers, url, default_specifier);
+      // Disable url-based location because there are multiple source contents
+      // for the same source url.
+      if (indirections.has(url)) {
+        const maybe_hash = indirections.get(url);
+        if (maybe_hash !== null) {
+          sources.set(
+            maybe_hash,
+            createSource({
+              ...sources.get(maybe_hash),
+              relative: toDynamicRelativeUrl(url, 0, directory),
+            }),
+          );
+          indirections.set(url, null);
+        }
+      } else {
+        indirections.set(url, hash);
+      }
+      if (urls.has(url)) {
+        let counter = urls.get(url);
+        counter += 1;
+        urls.set(url, counter);
+        relative = toDynamicRelativeUrl(url, counter, directory);
+      } else {
+        urls.set(url, 0);
+      }
+      sources.set(
+        hash,
+        createSource({
+          url,
+          content,
+          relative,
+          placeholder,
+          pruning,
+          inline: local_inline_source ?? global_inline_source,
+          exclusions: [...global_exclusion_array, ...local_exclusion_array],
+          shallow,
+        }),
+      );
+    }
+  }
 };
 
-export const lookupClassmapClosure = ({ sources }, location) => {
-  if (sources.has(location.hash)) {
-    return lookupSourceClosure(
-      sources.get(base),
-      location,
-    );
+export const lookupClassmapClosure = ({ sources, indirections }, location) => {
+  // Prefer hash over url to support dynamic sources.
+  if (location.hash !== null) {
+    if (sources.has(location.hash)) {
+      return lookupSourceClosure(sources.get(location.hash), location);
+    } else {
+      logWarning(
+        "Ignoring closure at %j because its source is missing",
+        location,
+      );
+      return null;
+    }
+  } else if (location.url !== null) {
+    if (indirections.has(location.url)) {
+      const hash = indirections.get(location.url);
+      if (hash === null) {
+        logWarning(
+          "Ignoring closure at %j because its source is dynamic",
+          location,
+        );
+        return null;
+      } else {
+        assert(sources.has(hash), InternalAppmapError, "missing resolved hash");
+        return lookupSourceClosure(sources.get(hash), location);
+      }
+    } else {
+      logWarning(
+        "Ignoring closure at %j because its source is missing",
+        location,
+      );
+      return null;
+    }
   } else {
-    logWarning(
-      "Missing source file for closure at %s, threating it as excluded.",
-      location,
+    throw new InternalAppmapError(
+      "location should either be hash-based or url-based",
     );
-    return null;
   }
 };
 

--- a/components/trace/appmap/classmap/index.mjs
+++ b/components/trace/appmap/classmap/index.mjs
@@ -41,6 +41,10 @@ export const addClassmapSource = (
   sources.set(
     hash,
     createSource(content, {
+  let relative = toRelativeUrl(url, directory);
+  if (relative === null) {
+    logWarning(
+      "Ignoring %j because it could not be expressed relatively to %j",
       url,
       relative,
       placeholder,
@@ -50,6 +54,8 @@ export const addClassmapSource = (
       shallow,
     }),
   );
+  } else if (content === null) {
+    logWarning("Ignoring %j because its content could not be loaded", url);
 };
 
 export const lookupClassmapClosure = ({ sources }, location) => {
@@ -78,15 +84,11 @@ const registerPackageEntity = (entities, dirname) => {
 
 export const compileClassmap = ({
   sources,
-  configuration: {
-    pruning,
-    "collapse-package-hierachy": collapse,
-    repository: { directory },
-  },
+  configuration: { pruning, "collapse-package-hierachy": collapse },
 }) => {
   const root = [];
-  for (const [url, source] of sources) {
-    const relative = toRelativeUrl(url, directory);
+  for (const source of sources.values()) {
+    const relative = getSourceRelativeUrl(source);
     const entities = toSourceClassmap(source);
     if (
       /* c8 ignore start */ !pruning ||

--- a/components/trace/appmap/classmap/index.mjs
+++ b/components/trace/appmap/classmap/index.mjs
@@ -3,9 +3,6 @@ import { assert } from "../../../util/index.mjs";
 import { toRelativeUrl } from "../../../url/index.mjs";
 import { logWarning } from "../../../log/index.mjs";
 import {
-  getLocationPosition,
-  getLocationBase,
-} from "../../../location/index.mjs";
 import {
   createSource,
   toSourceClassmap,
@@ -46,11 +43,10 @@ export const addClassmapSource = (
 };
 
 export const lookupClassmapClosure = ({ sources }, location) => {
-  const base = getLocationBase(location);
-  if (sources.has(base)) {
+  if (sources.has(location.hash)) {
     return lookupSourceClosure(
       sources.get(base),
-      getLocationPosition(location),
+      location,
     );
   } else {
     logWarning(

--- a/components/trace/appmap/classmap/index.mjs
+++ b/components/trace/appmap/classmap/index.mjs
@@ -2,6 +2,7 @@ import { InternalAppmapError } from "../../../error/index.mjs";
 import { assert } from "../../../util/index.mjs";
 import { toRelativeUrl } from "../../../url/index.mjs";
 import { logWarning } from "../../../log/index.mjs";
+import { lookupSpecifier } from "../../../specifier/index.mjs";
 import {
 import {
   createSource,
@@ -22,21 +23,30 @@ export const addClassmapSource = (
       pruning,
       "function-name-placeholder": placeholder,
       repository: { directory },
+      packages: specifiers,
+      "default-package": default_specifier,
+      exclude: global_exclusion_array,
+      "inline-source": global_inline_source,
     },
     sources,
   },
   { url, content, inline, exclude: exclusions, shallow },
 ) => {
   assert(!sources.has(url), "duplicate source url", InternalAppmapError);
+  const {
+    "inline-source": local_inline_source,
+    exclude: local_exclusion_array,
+    shallow,
+  } = lookupSpecifier(specifiers, url, default_specifier);
   sources.set(
-    url,
+    hash,
     createSource(content, {
       url,
-      directory,
+      relative,
       placeholder,
       pruning,
-      inline,
-      exclusions,
+      inline: local_inline_source ?? global_inline_source,
+      exclusions: [...global_exclusion_array, ...local_exclusion_array],
       shallow,
     }),
   );

--- a/components/trace/appmap/classmap/index.test.mjs
+++ b/components/trace/appmap/classmap/index.test.mjs
@@ -1,5 +1,4 @@
 import { assertDeepEqual, assertEqual } from "../../../__fixture__.mjs";
-import { makeLocation } from "../../../location/index.mjs";
 import {
   createConfiguration,
   extendConfiguration,
@@ -54,13 +53,11 @@ const default_exclusion = {
   );
 
   assertDeepEqual(
-    lookupClassmapClosure(
-      classmap,
-      makeLocation("protocol://host/home/directory/file.js", {
-        line: 1,
-        column: 0,
-      }),
-    ),
+    lookupClassmapClosure(classmap, {
+      url: file1.url,
+      line: 1,
+      column: 0,
+    }),
     {
       parameters: ["x"],
       shallow: true,

--- a/components/trace/appmap/classmap/index.test.mjs
+++ b/components/trace/appmap/classmap/index.test.mjs
@@ -36,9 +36,6 @@ const default_exclusion = {
   addClassmapSource(classmap, {
     url: "protocol://host/home/directory/file.js",
     content: "function f (x) {}\nfunction g (y) {}",
-    inline: true,
-    shallow: true,
-    exclude: [default_exclusion],
   });
 
   assertEqual(
@@ -104,6 +101,7 @@ const default_exclusion = {
       {
         pruning: false,
         "collapse-package-hierachy": false,
+        "inline-source": false,
       },
       "protocol://host/base/",
     ),
@@ -112,17 +110,11 @@ const default_exclusion = {
   addClassmapSource(classmap, {
     url: "protocol://host/home/file1.js",
     content: "function f (x) {}",
-    inline: false,
-    exclude: [default_exclusion],
-    shallow: false,
   });
 
   addClassmapSource(classmap, {
     url: "protocol://host/home/file2.js",
     content: "function g (x) {}",
-    inline: false,
-    exclude: [default_exclusion],
-    shallow: false,
   });
 
   assertDeepEqual(compileClassmap(classmap), [

--- a/components/trace/appmap/classmap/source.mjs
+++ b/components/trace/appmap/classmap/source.mjs
@@ -1,5 +1,4 @@
-import { toRelativeUrl } from "../../../url/index.mjs";
-import { logInfoWhen, logWarning } from "../../../log/index.mjs";
+import { logInfoWhen } from "../../../log/index.mjs";
 import { parseEstree } from "./parse.mjs";
 import { lookupEstreePath } from "./lookup.mjs";
 import {
@@ -19,22 +18,8 @@ const hashPosition = ({ line, column }) => `${String(line)}:${String(column)}`;
 
 export const createSource = (
   content,
-  { url, directory, inline, exclusions, shallow, pruning },
+  { url, relative, inline, exclusions, shallow, pruning },
 ) => {
-  if (content === null) {
-    logWarning("Will treat %j as empty because it could not be loaded", url);
-    content = "";
-  }
-  let relative = toRelativeUrl(url, directory);
-  if (relative === null) {
-    logWarning(
-      "Will treat %j as empty because it could not be expressed relatively to %j",
-      url,
-      directory,
-    );
-    content = "";
-    relative = "dummy/relative/path";
-  }
   const estree = parseEstree(url, content);
   const getExclusion = compileExclusionArray(exclusions);
   const context = {
@@ -52,7 +37,7 @@ export const createSource = (
   for (const entity of entities) {
     registerFunctionEntity(entity, null, infos);
   }
-  return { estree, entities, infos, paths: new Map(), pruning };
+  return { relative, estree, entities, infos, paths: new Map(), pruning };
 };
 
 const isFunctionEstree = ({ type }) =>
@@ -85,6 +70,8 @@ export const lookupSourceClosure = ({ estree, infos, paths }, position) => {
     return null;
   }
 };
+
+export const getSourceRelativeUrl = ({ relative }) => relative;
 
 export const toSourceClassmap = ({ entities, pruning, paths }) => {
   if (pruning) {

--- a/components/trace/appmap/classmap/source.mjs
+++ b/components/trace/appmap/classmap/source.mjs
@@ -16,10 +16,15 @@ const { Map, Set, String } = globalThis;
 
 const hashPosition = ({ line, column }) => `${String(line)}:${String(column)}`;
 
-export const createSource = (
+export const createSource = ({
+  url,
   content,
-  { url, relative, inline, exclusions, shallow, pruning },
-) => {
+  relative,
+  inline,
+  exclusions,
+  shallow,
+  pruning,
+}) => {
   const estree = parseEstree(url, content);
   const getExclusion = compileExclusionArray(exclusions);
   const context = {
@@ -37,7 +42,19 @@ export const createSource = (
   for (const entity of entities) {
     registerFunctionEntity(entity, null, infos);
   }
-  return { relative, estree, entities, infos, paths: new Map(), pruning };
+  return {
+    url,
+    content,
+    relative,
+    inline,
+    exclusions,
+    shallow,
+    pruning,
+    estree,
+    entities,
+    infos,
+    paths: new Map(),
+  };
 };
 
 const isFunctionEstree = ({ type }) =>

--- a/components/trace/appmap/classmap/source.test.mjs
+++ b/components/trace/appmap/classmap/source.test.mjs
@@ -2,23 +2,10 @@ import { assertEqual, assertDeepEqual } from "../../../__fixture__.mjs";
 
 import {
   createSource,
+  getSourceRelativeUrl,
   lookupSourceClosure,
   toSourceClassmap,
 } from "./source.mjs";
-
-assertDeepEqual(
-  toSourceClassmap(
-    createSource(null, {
-      pruning: true,
-      inline: true,
-      shallow: true,
-      directory: "protocol1://host1/home/",
-      url: "protocol2://host2/home/dirname/basename.js",
-      exclusions: [],
-    }),
-  ),
-  [],
-);
 
 {
   const source = createSource(
@@ -31,7 +18,7 @@ assertDeepEqual(
       pruning: true,
       inline: true,
       shallow: true,
-      directory: "protocol://host/home/",
+      relative: "dirname/basename.js",
       url: "protocol://host/home/dirname/basename.js",
       exclusions: [
         {
@@ -55,6 +42,8 @@ assertDeepEqual(
       ],
     },
   );
+
+  assertEqual(getSourceRelativeUrl(source), "dirname/basename.js");
 
   // present function //
   {

--- a/components/trace/appmap/classmap/source.test.mjs
+++ b/components/trace/appmap/classmap/source.test.mjs
@@ -1,5 +1,4 @@
 import { assertEqual, assertDeepEqual } from "../../../__fixture__.mjs";
-
 import {
   createSource,
   getSourceRelativeUrl,
@@ -8,40 +7,38 @@ import {
 } from "./source.mjs";
 
 {
-  const source = createSource(
-    `
-    function f (x) {}
-    function g (y) {}
-    var o = {};
-  `,
-    {
-      pruning: true,
-      inline: true,
-      shallow: true,
-      relative: "dirname/basename.js",
-      url: "protocol://host/home/dirname/basename.js",
-      exclusions: [
-        {
-          combinator: "or",
-          name: false,
-          "qualified-name": "^basename\\.g$",
-          "some-label": false,
-          "every-label": false,
-          excluded: true,
-          recursive: false,
-        },
-        {
-          combinator: "and",
-          name: true,
-          "qualified-name": true,
-          "some-label": true,
-          "every-label": true,
-          excluded: false,
-          recursive: false,
-        },
-      ],
-    },
-  );
+  const source = createSource({
+    url: "protocol://host/home/dirname/basename.js",
+    content: `
+      function f (x) {}
+      function g (y) {}
+      var o = {};
+    `,
+    pruning: true,
+    inline: true,
+    shallow: true,
+    relative: "dirname/basename.js",
+    exclusions: [
+      {
+        combinator: "or",
+        name: false,
+        "qualified-name": "^basename\\.g$",
+        "some-label": false,
+        "every-label": false,
+        excluded: true,
+        recursive: false,
+      },
+      {
+        combinator: "and",
+        name: true,
+        "qualified-name": true,
+        "some-label": true,
+        "every-label": true,
+        excluded: false,
+        recursive: false,
+      },
+    ],
+  });
 
   assertEqual(getSourceRelativeUrl(source), "dirname/basename.js");
 
@@ -59,11 +56,11 @@ import {
       },
     };
     assertDeepEqual(
-      lookupSourceClosure(source, { line: 2, column: 4 }, {}),
+      lookupSourceClosure(source, { line: 2, column: 6 }, {}),
       info,
     );
     assertDeepEqual(
-      lookupSourceClosure(source, { line: 2, column: 4 }, {}),
+      lookupSourceClosure(source, { line: 2, column: 6 }, {}),
       info,
     );
     assertDeepEqual(
@@ -73,10 +70,10 @@ import {
   }
 
   // excluded function //
-  assertEqual(lookupSourceClosure(source, { line: 3, column: 4 }, {}), null);
+  assertEqual(lookupSourceClosure(source, { line: 3, column: 6 }, {}), null);
 
   // missing function //
-  assertEqual(lookupSourceClosure(source, { line: 4, column: 4 }, {}), null);
+  assertEqual(lookupSourceClosure(source, { line: 4, column: 6 }, {}), null);
 
   assertDeepEqual(toSourceClassmap(source), [
     {

--- a/components/trace/appmap/event/index.mjs
+++ b/components/trace/appmap/event/index.mjs
@@ -4,6 +4,7 @@ import {
   createCounter,
   incrementCounter,
 } from "../../../util/index.mjs";
+import { parseLocation } from "../../../location/index.mjs";
 import { lookupClassmapClosure } from "../classmap/index.mjs";
 import { digestPayload } from "./payload.mjs";
 
@@ -26,8 +27,8 @@ const digestEventPair = (event1, event2, id1, id2, info) => [
 
 export const digestEventTrace = (root, classmap) => {
   const counter = createCounter(0);
-  const getClosureInfo = (location) =>
-    lookupClassmapClosure(classmap, location);
+  const getClosureInfo = (location_string) =>
+    lookupClassmapClosure(classmap, parseLocation(location_string));
   /* eslint-disable no-use-before-define */
   const digestTransparentBundle = ({ children }, _info) =>
     children.flatMap(loop);

--- a/components/trace/appmap/event/index.test.mjs
+++ b/components/trace/appmap/event/index.test.mjs
@@ -1,6 +1,9 @@
 import { assertDeepEqual } from "../../../__fixture__.mjs";
-import { createConfiguration } from "../../../configuration/index.mjs";
 import { stringifyLocation } from "../../../location/index.mjs";
+import {
+  createConfiguration,
+  extendConfiguration,
+} from "../../../configuration/index.mjs";
 import { createClassmap, addClassmapSource } from "../classmap/index.mjs";
 import { digestEventTrace } from "./index.mjs";
 
@@ -96,23 +99,24 @@ assertDeepEqual(
 
 // apply //
 for (const shallow of [true, false]) {
-  const classmap = createClassmap(createConfiguration("protocol://host/home"));
+  const classmap = createClassmap(
+    extendConfiguration(
+      createConfiguration("protocol://host/home"),
+      {
+        packages: [
+          {
+            glob: "*.js",
+            "inline-source": false,
+            shallow,
+          },
+        ],
+      },
+      "protocol://host/home/",
+    ),
+  );
   addClassmapSource(classmap, {
     url: "protocol://host/home/filename.js",
     content: "function f (x) {}",
-    inline: false,
-    exclude: [
-      {
-        combinator: "or",
-        "every-label": true,
-        "some-label": true,
-        "qualified-name": true,
-        name: true,
-        excluded: false,
-        recursive: true,
-      },
-    ],
-    shallow,
   });
   const location = stringifyLocation({
     url: "protocol://host/home/filename.js",

--- a/components/trace/appmap/event/index.test.mjs
+++ b/components/trace/appmap/event/index.test.mjs
@@ -120,6 +120,7 @@ for (const shallow of [true, false]) {
   });
   const location = stringifyLocation({
     url: "protocol://host/home/filename.js",
+    hash: null,
     line: 1,
     column: 0,
   });
@@ -149,6 +150,7 @@ for (const shallow of [true, false]) {
 {
   const location = stringifyLocation({
     url: "protocol://host/home/filename.js",
+    hash: null,
     line: 1,
     column: 0,
   });

--- a/components/trace/appmap/event/index.test.mjs
+++ b/components/trace/appmap/event/index.test.mjs
@@ -1,6 +1,6 @@
 import { assertDeepEqual } from "../../../__fixture__.mjs";
-import { makeLocation } from "../../../location/index.mjs";
 import { createConfiguration } from "../../../configuration/index.mjs";
+import { stringifyLocation } from "../../../location/index.mjs";
 import { createClassmap, addClassmapSource } from "../classmap/index.mjs";
 import { digestEventTrace } from "./index.mjs";
 
@@ -114,7 +114,8 @@ for (const shallow of [true, false]) {
     ],
     shallow,
   });
-  const location = makeLocation("protocol://host/home/filename.js", {
+  const location = stringifyLocation({
+    url: "protocol://host/home/filename.js",
     line: 1,
     column: 0,
   });
@@ -142,7 +143,8 @@ for (const shallow of [true, false]) {
 
 // missing apply >> transparent //
 {
-  const location = makeLocation("protocol://host/home/filename.js", {
+  const location = stringifyLocation({
+    url: "protocol://host/home/filename.js",
     line: 1,
     column: 0,
   });

--- a/components/trace/appmap/index.mjs
+++ b/components/trace/appmap/index.mjs
@@ -13,7 +13,7 @@ import {
 } from "./classmap/index.mjs";
 import { digestEventTrace } from "./event/index.mjs";
 import { orderEventArray } from "./ordering/index.mjs";
-import { getLocationUrl } from "./location.mjs";
+import { getOutputUrl } from "./output.mjs";
 
 const {
   Map,
@@ -206,7 +206,7 @@ export const compileTrace = (messages) => {
     printApplyDistribution,
   );
   return {
-    url: getLocationUrl(configuration),
+    url: getOutputUrl(configuration),
     content: appmap,
   };
 };

--- a/components/trace/appmap/index.test.mjs
+++ b/components/trace/appmap/index.test.mjs
@@ -3,7 +3,7 @@ import {
   createConfiguration,
   extendConfiguration,
 } from "../../configuration/index.mjs";
-import { makeLocation } from "../../location/index.mjs";
+import { stringifyLocation } from "../../location/index.mjs";
 import { compileTrace } from "./index.mjs";
 
 const { undefined } = globalThis;
@@ -40,7 +40,8 @@ const tabs = {
   event2: 6,
 };
 
-const location = makeLocation("protocol://host/home/dirname/filename.js", {
+const location = stringifyLocation({
+  url: "protocol://host/home/dirname/filename.js",
   line: 1,
   column: 0,
 });

--- a/components/trace/appmap/index.test.mjs
+++ b/components/trace/appmap/index.test.mjs
@@ -41,6 +41,7 @@ const tabs = {
 };
 
 const location = stringifyLocation({
+  hash: null,
   url: "protocol://host/home/dirname/filename.js",
   line: 1,
   column: 0,

--- a/components/trace/appmap/output.mjs
+++ b/components/trace/appmap/output.mjs
@@ -13,7 +13,7 @@ const pickBasename = ({ appmap_file: basename, "map-name": name }) => {
   }
 };
 
-export const getLocationUrl = (configuration) =>
+export const getOutputUrl = (configuration) =>
   toAbsoluteUrl(
     `${configuration.recorder}/${encodeURIComponent(
       sanitizePathFilename(`${pickBasename(configuration)}.appmap.json`),

--- a/components/trace/appmap/output.test.mjs
+++ b/components/trace/appmap/output.test.mjs
@@ -1,9 +1,9 @@
 import { platform } from "node:process";
 import { assertEqual } from "../../__fixture__.mjs";
-import { getLocationUrl } from "./location.mjs";
+import { getOutputUrl } from "./output.mjs";
 
 assertEqual(
-  getLocationUrl({
+  getOutputUrl({
     recorder: "process",
     appmap_dir: "protocol://host/path/",
     appmap_file: "foo/bar",
@@ -15,7 +15,7 @@ assertEqual(
 );
 
 assertEqual(
-  getLocationUrl({
+  getOutputUrl({
     recorder: "process",
     appmap_dir: "protocol://host/dirname/",
     appmap_file: "basename",
@@ -25,7 +25,7 @@ assertEqual(
 );
 
 assertEqual(
-  getLocationUrl({
+  getOutputUrl({
     recorder: "process",
     appmap_dir: "protocol://host/dirname/",
     appmap_file: null,
@@ -35,7 +35,7 @@ assertEqual(
 );
 
 assertEqual(
-  getLocationUrl({
+  getOutputUrl({
     recorder: "process",
     appmap_dir: "protocol://host/dirname/",
     appmap_file: null,

--- a/schema/definitions/message-source.yaml
+++ b/schema/definitions/message-source.yaml
@@ -2,24 +2,13 @@ type: object
 additionalProperties: false
 required:
   - type
-  - content
   - url
-  - shallow
-  - inline
-  - exclude
+  - content
 properties:
   type:
     const: source
+  url:
+    $ref: url
   content:
     type: string
     nullable: true
-  url:
-    $ref: url
-  shallow:
-    type: boolean
-  inline:
-    type: boolean
-  exclude:
-    type: array
-    items:
-      $ref: exclusion-cooked

--- a/test/cases/eval/main.mjs
+++ b/test/cases/eval/main.mjs
@@ -2,4 +2,7 @@
 /* eslint local/no-globals: ["error", "eval"] */
 function f() {}
 f();
-eval("function g () {}; g();");
+const codes = ["function g () {}; g();", "function h () {}; h();"];
+for (const code of codes) {
+  eval(code);
+}

--- a/test/cases/eval/process/main.subset.yaml
+++ b/test/cases/eval/process/main.subset.yaml
@@ -1,6 +1,6 @@
 classMap:
   - type: package
-    name: "."
+    name: .
     children:
       - type: class
         name: main
@@ -8,17 +8,28 @@ classMap:
           - type: function
             name: f
             location: main.mjs:3
-            static: false
-            source: null
-            labels: []
   - type: package
     name: main.mjs
     children:
       - type: class
+        name: eval-7-2
         children:
           - type: function
             name: g
-            static: false
-            source: null
-            comment: null
-            labels: []
+            location: main.mjs/eval-7-2.js#0:1
+      - type: class
+        name: eval-7-2
+        children:
+          - type: function
+            name: h
+            location: main.mjs/eval-7-2.js#1:1
+events:
+  - event: call
+    method_id: f
+  - event: return
+  - event: call
+    method_id: g
+  - event: return
+  - event: call
+    method_id: h
+  - event: return

--- a/test/cases/jest-transformer-preset/appmap.yml
+++ b/test/cases/jest-transformer-preset/appmap.yml
@@ -1,6 +1,4 @@
 recorder: jest
-log:
-  level: debug
 command: npx jest --no-cache
 command-win32: npx.cmd jest --no-cache
 appmap_dir: .


### PR DESCRIPTION
### Context

Sources can share the same url but have different contents:
- Dynamic code evaluation.
- Impure jest transformers.
- File overwritting.

This is amplified by the fact that different node processes may share the same session and each session has a unique source pool. A shared source pool was required to support instrumentation in separate process. This is the case for jest transformers (which technically is in the same process but in a different different global object).

### Problem

Identifying a source from its url is not longer sufficient when dynamic sources are present. 

### Solution

When a source content is loaded on the frontend, we hash both the url and the content of the source to identify it on the backend. This enable support for dynamic sources. When the content is not loaded on the frontend, we use the old url-only identification which does not support dynamic sources.