### PR TITLE
fix: make pure serialization actually pure

### DIFF
--- a/components/hook-http-server/node/index.test.mjs
+++ b/components/hook-http-server/node/index.test.mjs
@@ -252,9 +252,9 @@ assertDeepEqual(
               type: "hash",
               length: 3,
               properties: {
-                0: "String",
-                param1: "String",
-                param2: "String",
+                0: "string",
+                param1: "string",
+                param2: "string",
               },
             },
           },

--- a/components/serialization/default/index.test.mjs
+++ b/components/serialization/default/index.test.mjs
@@ -107,6 +107,22 @@ validateSerial(
   ),
 );
 
+// object pure //
+validateSerial(
+  testSerialize(
+    {
+      "impure-printing": false,
+      "impure-constructor-naming": false,
+      "impure-hash-inspection": false,
+    },
+    {
+      get [Symbol.toStringTag]() {
+        throw new Error("impure serialization");
+      },
+    },
+  ),
+);
+
 // object impure //
 validateSerial(
   testSerialize(


### PR DESCRIPTION
It was assumed that `Object.prototype.toString.call(any)` is always pure. But actually it performs `any[Symbol.toStringTag]` which can trigger getters or proxy traps. Unfortunately we have to use `typeof` which provides even less information.