### PR TITLE
avoid null as argument for toEntries (in sql digester)

### DIFF
--- a/components/trace/appmap/event/payload.mjs
+++ b/components/trace/appmap/event/payload.mjs
@@ -193,7 +193,7 @@ const digesters = {
       sql,
       explain_sql: undefined,
     },
-    message: toEntries(parameters).map(digestParameterSerialTuple),
+    message: toEntries(parameters || {}).map(digestParameterSerialTuple),
   }),
   answer: ({}, _options) => ({}),
 };

--- a/components/trace/appmap/event/payload.test.mjs
+++ b/components/trace/appmap/event/payload.test.mjs
@@ -458,6 +458,26 @@ assertDeepEqual(
   },
 );
 
+// query empty params//
+
+assertDeepEqual(
+  digestPayload({
+    type: "query",
+    database: "database",
+    version: "version",
+    sql: "sql"
+  }),
+  {
+    sql_query: {
+      database_type: "database",
+      server_version: "version",
+      sql: "sql",
+      explain_sql: undefined,
+    },
+    message: [],
+  },
+);
+
 // answer //
 assertDeepEqual(
   digestPayload(


### PR DESCRIPTION
- fix `TypeError: Cannot convert undefined or null to object` in `message: toEntries(parameters).map(digestParameterSerialTuple)` (.npm/_npx/5cc1c6504f9acf64/node_modules/@appland/appmap-agent-js/dist/bundles/batch.mjs:3620 for v13.2.1)
by passing a default empty parameters if is null/undefined (maybe we can fix toEntries to accept null/undef params?)
- added test to cover empty parameters case

