### PR TITLE
avoid null as argument for toEntries (in sql digester)

### DIFF
--- a/components/trace/appmap/event/payload.mjs
+++ b/components/trace/appmap/event/payload.mjs
@@ -193,7 +193,7 @@ const digesters = {
       sql,
       explain_sql: undefined,
     },
-    message: toEntries(parameters).map(digestParameterSerialTuple),
+    message: toEntries(parameters || {}).map(digestParameterSerialTuple),
   }),
   answer: ({}, _options) => ({}),
 };

--- a/components/trace/appmap/event/payload.test.mjs
+++ b/components/trace/appmap/event/payload.test.mjs
@@ -458,6 +458,25 @@ assertDeepEqual(
   },
 );
 
+// query with empty parameters//
+assertDeepEqual(
+  digestPayload({
+    type: "query",
+    database: "database",
+    version: "version",
+    sql: "sql"
+  }),
+  {
+    sql_query: {
+      database_type: "database",
+      server_version: "version",
+      sql: "sql",
+      explain_sql: undefined,
+    },
+    message: [],
+  },
+);
+
 // answer //
 assertDeepEqual(
   digestPayload(


### PR DESCRIPTION
- fixed passing empty parameters to **toEntries** in sql payload digester (to fix `TypeError: Cannot convert undefined or null to object` in _@appland/appmap-agent-js/dist/bundles/batch.mjs:3620_ for _v13.2.1_) by defaulting null/undefined parameters to empty object. Maybe we can make **toEntries** accept null/undefined argument if that is the desired behavior
- added test for cover empty parameters case
