### PR TITLE
fix: Support class features when transforming source code

### DIFF
--- a/component/signature.mjs
+++ b/component/signature.mjs
@@ -84,7 +84,7 @@ const parseBabelLog = (content, url) => {
     return parseBabel(content, {
       sourceType: "module",
       sourceFilename: url,
-      plugins: ["estree"],
+      plugins: [["estree", { classFeatures: true }]],
     }).program;
   } catch (error) {
     error.message += ` at ${url}`;

--- a/components/instrumentation/default/__fixture__.mjs
+++ b/components/instrumentation/default/__fixture__.mjs
@@ -10,6 +10,6 @@ export const normalize = (code, source) =>
       ecmaVersion: 2021,
       sourceType: source,
       allowAwaitOutsideFunction: source === "module",
-      plugins: ["estree"],
+      plugins: [["estree", { classFeatures: true }]],
     }).program,
   );

--- a/components/instrumentation/default/index.test.mjs
+++ b/components/instrumentation/default/index.test.mjs
@@ -92,6 +92,21 @@ const instrumentation = createInstrumentation(
 }
 
 {
+  const js = "class Klass { prop; }";
+  const source = createSource("protocol://host/base/foo.js", js);
+  assertDeepEqual(
+    normalizeContent(
+      instrument(instrumentation, source, createMirrorMapping(source)),
+    ),
+    {
+      url: "protocol://host/base/foo.js",
+      content: normalize(js, "script"),
+      sources: [source],
+    },
+  );
+}
+
+{
   const source = createSource("protocol://host/base/bar.js", "456;");
   assertDeepEqual(
     normalizeContent(

--- a/components/source/default/parse.mjs
+++ b/components/source/default/parse.mjs
@@ -60,7 +60,7 @@ export const parseEstree = (url, content) => {
   } else if (/^[ \t\n]*\/(\/[ \t]*|\*[ \t\n]*)@flow/u.test(content)) {
     plugins = ["flow"];
   }
-  plugins.push("estree", "jsx");
+  plugins.push(["estree", { classFeatures: true }], "jsx");
   let result;
   try {
     result = parseBabel(content, {

--- a/components/source/default/parse.test.mjs
+++ b/components/source/default/parse.test.mjs
@@ -1,4 +1,4 @@
-import { assertDeepEqual } from "../../__fixture__.mjs";
+import { assertDeepEqual, assertEqual } from "../../__fixture__.mjs";
 import {
   parseEstree,
   printComment,
@@ -39,6 +39,16 @@ assertDeepEqual(
     },
   },
 );
+
+{
+  const parsedClass = parseEstree(
+    "protocol://host/dirname/filename.js?search#hash",
+    "class Foo { prop; }",
+  );
+
+  // make sure property definitions have estree-compliant type
+  assertEqual(parsedClass.body[0].body.body[0].type, "PropertyDefinition");
+}
 
 assertDeepEqual(
   getLeadingCommentArray(


### PR DESCRIPTION
appmap-agent-js uses @babel/parser to parse the ECMAScript code for transformation; the output generated by that library is not 100% estree-compliant [1]. It has an `estree` plugin that reverts the deviations; however, by default not all of them are supported (apparently for @babel/parser's own backward compatibility reasons). Fortunately it has a config setting that enables them.

One of these differences is that the standard node type of PropertyDefinition is called ClassProperty instead, which made the transformer unable to correctly handle ES classes.

[1] https://babeljs.io/docs/babel-parser#output

Fixes #199