### PR TITLE
feat: make babel parsing options configurable by the user

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,4 +5,5 @@
 /doc
 /node_modules
 /test/pack
+/test/cases/apply-source/source.mjs
 /tmp

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -314,6 +314,8 @@ The agent filter code objects (functions or objects/classes) based on a format c
         * `enabled <boolean>` Indicates whether the filtered file should be instrumented or not. *Default*: `true`.
         * `shallow <boolean>` Indicates whether the filtered file should
         * `exclude <Exclusion[]>` Additional code object filtering for the matched file.
+        * `source-type "script" | "module" | null` The `sourceType` options given to `@babel/parser`. *Default*: `null` attempt to retrieve this information from the extension of the file, else provide `"unambiguous"`.
+        * `parsing <array>` A set of plugin names to give to `@babel/parser`. Options can be given to plugins by providing a pair instead of just the name -- eg: `["recordAndtuple", {syntaxType: bar}]`. *Default*: `null` attempt to guess the plugins based on the extension and content of the file.
         * `... <Specifier>` Extends from any specifier format.
 * `exclude <Exclusion[]>` Code object filtering to apply to every file.
 * `source <boolean>` Indicates whether to include source code in the appmap file. *Default* `false`.

--- a/components/configuration-accessor/default/index.test.mjs
+++ b/components/configuration-accessor/default/index.test.mjs
@@ -154,6 +154,8 @@ assertDeepEqual(
     shallow: false,
     exclude: [],
     "inline-source": null,
+    "source-type": null,
+    parsing: null,
   },
 );
 
@@ -186,6 +188,8 @@ assertDeepEqual(
       },
     ],
     "inline-source": null,
+    "source-type": null,
+    parsing: null,
   },
 );
 

--- a/components/configuration-process/node/index.test.mjs
+++ b/components/configuration-process/node/index.test.mjs
@@ -128,6 +128,8 @@ assertThrow(
       shallow: false,
       exclude: [],
       "inline-source": null,
+      "source-type": null,
+      parsing: null,
     },
   );
   assertDeepEqual(
@@ -140,6 +142,8 @@ assertThrow(
       shallow: false,
       exclude: [],
       "inline-source": null,
+      "source-type": null,
+      parsing: null,
     },
   );
   assertDeepEqual(
@@ -152,6 +156,8 @@ assertThrow(
       shallow: false,
       exclude: [],
       "inline-source": null,
+      "source-type": null,
+      parsing: null,
     },
   );
 }

--- a/components/configuration/default/index.mjs
+++ b/components/configuration/default/index.mjs
@@ -115,6 +115,8 @@ const normalizeDefaultPackage = (package_, _base) => {
     shallow: false,
     exclude: [],
     "inline-source": null,
+    "source-type": null,
+    parsing: null,
     ...package_,
   };
 };
@@ -188,23 +190,29 @@ const normalizePackageMatcher = (matcher, base) => {
   const {
     enabled,
     shallow,
-    "inline-source": inline,
+    "inline-source": inline_source,
     exclude,
+    "source-type": source_type,
+    parsing,
     ...rest
   } = {
     enabled: true,
     "inline-source": null,
     shallow: hasOwnProperty(matcher, "dist"),
     exclude: [],
+    "source-type": null,
+    parsing: null,
     ...matcher,
   };
   return [
     createMatcher(rest, base),
     {
       enabled,
-      "inline-source": inline,
+      "inline-source": inline_source,
       shallow,
       exclude: exclude.map(normalizeExclusion),
+      "source-type": source_type,
+      parsing,
     },
   ];
 };
@@ -535,6 +543,8 @@ export const createConfiguration = (home) => ({
     shallow: false,
     exclude: [],
     "inline-source": null,
+    "source-type": null,
+    parsing: null,
   },
   packages: [],
   exclude: [

--- a/components/configuration/default/index.test.mjs
+++ b/components/configuration/default/index.test.mjs
@@ -44,11 +44,14 @@ assertDeepEqual(
 );
 
 // default-package //
+
 assertDeepEqual(extend("default-package", true, "protocol://host/base/"), {
   enabled: true,
   shallow: false,
   "inline-source": null,
   exclude: [],
+  "source-type": null,
+  parsing: null,
 });
 
 // packages //
@@ -64,6 +67,8 @@ assertDeepEqual(extend("default-package", true, "protocol://host/base/"), {
     enabled: true,
     exclude: [],
     shallow: false,
+    "source-type": null,
+    parsing: null,
   });
   assertEqual(matchUrl(matcher, "protocol://host/base/lib/foo.js"), true);
   assertEqual(matchUrl(matcher, "protocol://host/base/lib/foo.mjs"), false);

--- a/components/instrumentation/default/source.mjs
+++ b/components/instrumentation/default/source.mjs
@@ -16,15 +16,17 @@ export const createSource = (
     "postmortem-function-exclusion": postmortem,
   },
 ) => {
-  const { enabled, exclude: local_criteria } = lookupUrl(
-    package_matcher_array,
-    url,
-    default_package,
-  );
+  const {
+    enabled,
+    exclude: local_criteria,
+    "source-type": source,
+    parsing: plugins,
+  } = lookupUrl(package_matcher_array, url, default_package);
   if (enabled) {
     return {
       postmortem,
       enabled: true,
+      parsing: { source, plugins },
       criteria: [...local_criteria, ...global_criteria],
       url,
       content,
@@ -36,6 +38,7 @@ export const createSource = (
     return {
       postmortem,
       enabled: false,
+      parsing: { source, plugins },
       criteria: [],
       url,
       content,
@@ -52,8 +55,8 @@ export const createSource = (
 
 export const parseSource = (source) => {
   if (source.program === null) {
-    const { url, content } = source;
-    const program = parseEstree({ url, content });
+    const { url, content, parsing } = source;
+    const program = parseEstree({ url, content }, parsing);
     source.program = program;
     return program;
   } else {

--- a/components/instrumentation/default/visit.test.mjs
+++ b/components/instrumentation/default/visit.test.mjs
@@ -18,7 +18,7 @@ const {
 
 const instrument = (options) =>
   generate(
-    visit(parseEstree(options.source), {
+    visit(parseEstree(options.source, { source: null, plugins: null }), {
       url: options.source.url,
       apply: "APPLY",
       eval: { hidden: "EVAL", aliases: ["eval"] },

--- a/components/source/default/criteria.test.mjs
+++ b/components/source/default/criteria.test.mjs
@@ -31,10 +31,13 @@ const bottom = {
 const FILE = "file";
 
 const test = (code, criteria, path, excluded) => {
-  const node = parseEstree({
-    url: `protocol://host/directory/${FILE}.ext`,
-    content: code,
-  });
+  const node = parseEstree(
+    {
+      url: `protocol://host/directory/${FILE}.ext`,
+      content: code,
+    },
+    { source: "module", plugins: [] },
+  );
   let parent = null;
   let entity = toEntity(node, FILE);
   for (const segment of path.split("/")) {

--- a/components/source/default/entity.test.mjs
+++ b/components/source/default/entity.test.mjs
@@ -5,10 +5,13 @@ import { toEntity } from "./entity.mjs";
 const testFile = (code, file, pattern) => {
   assertMatchJSON(
     toEntity(
-      parseEstree({
-        url: `protocol://host/directory/${file}`,
-        content: code,
-      }),
+      parseEstree(
+        {
+          url: `protocol://host/directory/${file}`,
+          content: code,
+        },
+        { source: null, plugins: null },
+      ),
       file.split(".")[0],
     ),
     pattern,

--- a/components/source/default/index.test.mjs
+++ b/components/source/default/index.test.mjs
@@ -24,7 +24,7 @@ const createSourceHelper = (url, content) =>
   createSource({
     url,
     content,
-    program: parseEstree({ url, content }),
+    program: parseEstree({ url, content }, { source: "module", plugins: [] }),
   });
 
 ////////////////////////////

--- a/components/trace/appmap/codebase/index.mjs
+++ b/components/trace/appmap/codebase/index.mjs
@@ -40,6 +40,8 @@ const registerFileUrl = (
       enabled,
       exclude: criteria,
       "inline-source": inline,
+      "source-type": source,
+      parsing: plugins,
       shallow,
     } = lookupUrl(package_matcher_array, url, default_package);
     if (enabled) {
@@ -47,22 +49,24 @@ const registerFileUrl = (
         inline: inline === null ? global_inline : inline,
         criteria: [...criteria, ...global_criteria],
         shallow,
+        parsing: { source, plugins },
         versions: new Map(),
       });
+      return true;
     } else {
       disabled.add(url);
+      return false;
     }
-    return enabled;
   }
 };
 
 const registerFile = ({ url, hash, content }, codebase) => {
-  const { versions, criteria } = codebase.get(url);
+  const { versions, criteria, parsing } = codebase.get(url);
   const version = String(versions.size);
   const source = createSource({
     url,
     content,
-    program: parseEstree({ url, content }),
+    program: parseEstree({ url, content }, parsing),
   });
   applyExclusionCriteria(source, criteria);
   versions.set(hash, { version, source });

--- a/components/url/default/index.mjs
+++ b/components/url/default/index.mjs
@@ -116,6 +116,19 @@ export const getUrlExtension = (url) => {
   }
 };
 
+const prefixDot = (string) => `.${string}`;
+
+export const getUrlExtensionArray = (url) => {
+  const filename = getUrlFilename(url);
+  if (filename === null) {
+    return null;
+  } else {
+    const extensions = filename.split(".");
+    extensions.shift();
+    return extensions.map(prefixDot);
+  }
+};
+
 // Alternatively:
 //   url.match(/([^\/]+)(\.[^/#]*)(#.*)?$/)[2]
 export const getLastUrlExtension = (url) => {

--- a/components/url/default/index.test.mjs
+++ b/components/url/default/index.test.mjs
@@ -1,4 +1,4 @@
-import { assertEqual } from "../../__fixture__.mjs";
+import { assertEqual, assertDeepEqual } from "../../__fixture__.mjs";
 
 import {
   toAbsoluteUrl,
@@ -8,6 +8,7 @@ import {
   getUrlBasename,
   getUrlExtension,
   getLastUrlExtension,
+  getUrlExtensionArray,
 } from "./index.mjs";
 
 ////////////////////
@@ -52,6 +53,24 @@ assertEqual(
     "protocol://host/directory/basename.extension1.extension2#hash",
   ),
   ".extension1.extension2",
+);
+
+//////////////////////////
+// getUrlExtensionArray //
+//////////////////////////
+
+assertEqual(getUrlExtensionArray("protocol://host/directory/#hash"), null);
+
+assertDeepEqual(
+  getUrlExtensionArray("protocol://host/directory/filename#hash"),
+  [],
+);
+
+assertDeepEqual(
+  getUrlExtensionArray(
+    "protocol://host/directory/basename.extension1.extension2#hash",
+  ),
+  [".extension1", ".extension2"],
 );
 
 /////////////////////////

--- a/schema/definitions/matcher-module.yaml
+++ b/schema/definitions/matcher-module.yaml
@@ -20,6 +20,10 @@ anyOf:
       inline-source:
         type: boolean
         nullable: true
+      source-type:
+        $ref: source-type
+      parsing:
+        $ref: parsing
   - type: object
     additionalProperties: false
     required:
@@ -36,6 +40,10 @@ anyOf:
       inline-source:
         type: boolean
         nullable: true
+      source-type:
+        $ref: source-type
+      parsing:
+        $ref: parsing
   - type: object
     additionalProperties: false
     required:
@@ -54,6 +62,10 @@ anyOf:
       inline-source:
         type: boolean
         nullable: true
+      source-type:
+        $ref: source-type
+      parsing:
+        $ref: parsing
   - type: object
     additionalProperties: false
     required:
@@ -74,6 +86,10 @@ anyOf:
       inline-source:
         type: boolean
         nullable: true
+      source-type:
+        $ref: source-type
+      parsing:
+        $ref: parsing
   - type: object
     additionalProperties: false
     required:
@@ -92,3 +108,7 @@ anyOf:
       inline-source:
         type: boolean
         nullable: true
+      source-type:
+        $ref: source-type
+      parsing:
+        $ref: parsing

--- a/schema/definitions/module-cooked.yaml
+++ b/schema/definitions/module-cooked.yaml
@@ -5,6 +5,7 @@ required:
   - shallow
   - inline-source
   - exclude
+  - parsing
 properties:
   enabled:
     type: boolean
@@ -15,3 +16,7 @@ properties:
     nullable: true
   exclude:
     $ref: exclude-cooked
+  source-type:
+    $ref: source-type
+  parsing:
+    $ref: parsing

--- a/schema/definitions/module.yaml
+++ b/schema/definitions/module.yaml
@@ -12,3 +12,7 @@ anyOf:
         nullable: true
       exclude:
         $ref: exclude
+      source-type:
+        $ref: source-type
+      parsing:
+        $ref: parsing

--- a/schema/definitions/parsing.yaml
+++ b/schema/definitions/parsing.yaml
@@ -1,0 +1,11 @@
+type: array
+nullable: true
+items:
+  anyOf:
+    - type: string
+    - type: array
+      minItems: 2
+      maxItems: 2
+      items:
+        - type: string
+        - type: object

--- a/schema/definitions/source-type.yaml
+++ b/schema/definitions/source-type.yaml
@@ -1,0 +1,4 @@
+enum:
+  - null
+  - script
+  - module

--- a/test/cases/apply-source/appmap.yml
+++ b/test/cases/apply-source/appmap.yml
@@ -1,7 +1,11 @@
 recorder: process
+pruning: false
 packages:
   path: source.mjs
   enabled: true
+  source-type: module
+  parsing:
+    - decorators
 command: node script.mjs
 appmap_dir: .
 appmap_file: script

--- a/test/cases/apply-source/generate-source-map.mjs
+++ b/test/cases/apply-source/generate-source-map.mjs
@@ -5,13 +5,13 @@ const generator = new SourceMapGenerator();
 const { URL } = globalThis;
 generator.addMapping({
   source: "source.mjs",
-  original: { line: 2, column: 0 },
+  original: { line: 3, column: 0 },
   generated: { line: 1, column: 0 },
 });
 generator.addMapping({
   source: "source.mjs",
-  original: { line: 4, column: 0 },
-  generated: { line: 3, column: 0 },
+  original: { line: 6, column: 0 },
+  generated: { line: 4, column: 0 },
 });
 await writeFileAsync(
   new URL("source.map", import.meta.url),

--- a/test/cases/apply-source/process/script.subset.yaml
+++ b/test/cases/apply-source/process/script.subset.yaml
@@ -7,25 +7,28 @@ classMap:
         children:
           - type: function
             name: f
-            location: ./source.mjs:2
+            location: ./source.mjs:3
             static: false
             source:
             comment: "// Source //"
             labels: []
           - type: function
             name: g
-            location: ./source.mjs:4
+            location: ./source.mjs:6
             static: false
             source:
             comment:
             labels: []
+          - type: class
+            name: c
+            children: []
 events:
   - event: call
     id: 1
     defined_class: source
     method_id: f
     path: ./source.mjs
-    lineno: 2
+    lineno: 3
     parameters: []
   - event: return
     id: 2
@@ -39,7 +42,7 @@ events:
     defined_class: source
     method_id: g
     path: ./source.mjs
-    lineno: 4
+    lineno: 6
     parameters: []
   - event: return
     id: 4

--- a/test/cases/apply-source/script.mjs
+++ b/test/cases/apply-source/script.mjs
@@ -1,5 +1,7 @@
 function f() {}
 f();
+
 function g(_x) {}
 g();
+
 //# sourceMappingURL=source.map

--- a/test/cases/apply-source/source.mjs
+++ b/test/cases/apply-source/source.mjs
@@ -1,5 +1,10 @@
 // Source //
+
 function f(_x) {}
 f();
+
 function g() {}
 g();
+
+@a
+class c {}


### PR DESCRIPTION
The user can now overwrite the options provided to `@babel/parser`. The default is `source-type = null` and `parsing = null` which has the same behavior as before and attempt to guess suitable values from file url and content.

fixes https://github.com/getappmap/appmap-agent-js/issues/198