### PR TITLE
test: add env vars to disable db tests

### DIFF
--- a/components/hook-query/node/mysql.mjs
+++ b/components/hook-query/node/mysql.mjs
@@ -1,3 +1,5 @@
+/* c8 ignore start */
+
 import { toString, spyOnce, assignProperty } from "../../util/index.mjs";
 import { requirePeerDependency } from "../../peer/index.mjs";
 import { getCurrentGroup } from "../../group/index.mjs";
@@ -33,9 +35,9 @@ export const hook = (
       directory,
       strict: mysql === true,
     });
-    /* c8 ignore start */ if (Mysql === null) {
+    if (Mysql === null) {
       return [];
-    } /* c8 ignore stop */ else {
+    } else {
       const { createConnection, createQuery } = Mysql;
       const { __proto__: prototype } = createConnection({});
       const { query: original } = prototype;

--- a/components/hook-query/node/mysql.test.mjs
+++ b/components/hook-query/node/mysql.test.mjs
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { platform as getPlatform } from "node:os";
+import { platform, env, exit } from "node:process";
 import { rm as rmAsync } from "node:fs/promises";
 import Mysql from "mysql";
 import { assertEqual, assertDeepEqual } from "../../__fixture__.mjs";
@@ -7,6 +7,7 @@ import { getUuid } from "../../uuid/random/index.mjs";
 import { toAbsoluteUrl } from "../../url/index.mjs";
 import { getTmpUrl, convertFileUrlToPath } from "../../path/index.mjs";
 import { testHookAsync } from "../../hook-fixture/index.mjs";
+import { hasOwnProperty } from "../../util/index.mjs";
 import * as HookMysql from "./mysql.mjs";
 
 const {
@@ -18,6 +19,13 @@ const {
   URL,
   undefined,
 } = globalThis;
+
+if (
+  hasOwnProperty(env, "SKIP_TEST") &&
+  env.SKIP_TEST.toLowerCase().includes("mysql")
+) {
+  exit(0);
+}
 
 const promiseTermination = (child) =>
   new Promise((resolve, reject) => {
@@ -135,10 +143,10 @@ const proceedAsync = async () => {
 if (getOwnPropertyDescriptor(process.env, "TRAVIS") !== undefined) {
   // TODO: Investigate why it fails on travis/windows
   // > ECONNREFUSED 127.0.0.1:3306
-  if (getPlatform() !== "win32") {
+  if (platform !== "win32") {
     await proceedAsync();
   }
-} else if (getPlatform() !== "win32") {
+} else {
   const url = toAbsoluteUrl(getUuid(), getTmpUrl());
   assertDeepEqual(
     await promiseTermination(

--- a/components/hook-query/node/pg.mjs
+++ b/components/hook-query/node/pg.mjs
@@ -1,3 +1,5 @@
+/* c8 ignore start */
+
 import { toString, spyOnce, assignProperty } from "../../util/index.mjs";
 import { requirePeerDependency } from "../../peer/index.mjs";
 import { getCurrentGroup } from "../../group/index.mjs";
@@ -36,9 +38,9 @@ export const hook = (
       directory,
       strict: pg === true,
     });
-    /* c8 ignore start */ if (Postgres === null) {
+    if (Postgres === null) {
       return [];
-    } /* c8 ignore stop */ else {
+    } else {
       const { Client, Query } = Postgres;
       const { prototype } = Client;
       const { query: original } = prototype;


### PR DESCRIPTION
These tests are slow and require setup. It is helpful to be able to skip them.